### PR TITLE
Fix: lightcurve figure sometimes not appearing 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "dash-mantine-components",
     "dash-iconify",
     "dash-extensions",
-    "visdcc",
     "pydantic",
 ]
 requires-python = ">=3.11,<3.14"

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -4,7 +4,6 @@ import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_iconify import DashIconify
 
-import visdcc
 import json
 from ..styles import CARD_STYLE
 
@@ -305,11 +304,8 @@ def format_object_metadata(object_id, meta, logger=None):
             ),
             expressive_card(
                 children=[
-                    dcc.Loading(
-                        visdcc.Run_js(
-                            id="aladin-lite-runjs",
-                        )
-                    ),
+                    # A hidden div to receive the "success" message from our JS
+                    html.Div(id="aladin-status-dummy", style={"display": "none"}),
                     html.Div(
                         id="aladin-lite-div",
                         style={"width": "100%", "height": "500px"},

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -269,9 +269,8 @@ def format_object_metadata(object_id, meta, logger=None):
                     value = str(value[0])
             summary_items.append(
                 dmc.Text(
-                    dmc.Text(f"{label}: {value}"),
-                    style={"marginBottom": "6px"},
-                )
+                    f"{label}: {value}",
+                ),
             )
 
     return dmc.Stack(

--- a/tarxiv/dashboard/pages/lightcurve.py
+++ b/tarxiv/dashboard/pages/lightcurve.py
@@ -1,5 +1,5 @@
 import dash
-from dash import html, callback, no_update, dcc
+from dash import html, callback, no_update, dcc, clientside_callback
 from dash.dependencies import Input, Output, State
 from dash_extensions import Keyboard
 from flask import current_app, request
@@ -167,46 +167,50 @@ def search_navigation(n_clicks, n_keydowns, object_id):
     return f"/lightcurve/{object_id}"
 
 
-@callback(
-    Output("aladin-lite-runjs", "run"),
-    # Triggered by the search-store or metadata container being updated
+clientside_callback(
+    """
+    function(storeData) {
+    if (!storeData) return;
+
+    const ra = storeData.ra_deg[0].value;
+    const dec = storeData.dec_deg[0].value;
+
+    // The ID Plotly generates for pattern-matching is complex,
+    // so we target the container expressive_card or a stable parent.
+    const graphContainer = document.body;
+
+    const observer = new MutationObserver((mutations, obs) => {
+        // Look for the Plotly internal class that signifies rendering is done
+        const graphExists = document.querySelector('.js-plotly-plot');
+
+        if (graphExists) {
+            obs.disconnect(); // Stop watching
+
+            window.A.init.then(() => {
+                const container = document.getElementById('aladin-lite-div');
+                if (container) {
+                    container.innerHTML = '';
+                    window.A.aladin('#aladin-lite-div', {
+                        survey: 'P/PanSTARRS/DR1/color-z-zg-g',
+                        target: ra + ' ' + dec,
+                        fov: 0.025,
+                    });
+                }
+            });
+        }
+    });
+
+    observer.observe(graphContainer, {
+        childList: true,
+        subtree: true
+    });
+
+    return "Observer active";
+}
+    """,
+    Output("aladin-status-dummy", "children"),
     Input("lightcurve-meta-store", "data"),
 )
-def update_aladin_viewer(store_data):
-    """Triggers the Aladin JS ONLY when new data arrives."""
-    if not store_data:
-        return no_update
-
-    # Extract RA/Dec from your stored metadata
-    # (Assuming your store_data has these keys)
-    print(f"Received store data for Aladin: {store_data}")
-    ra = store_data.get("ra_deg", 0)[0].get("value", 0)
-    dec = store_data.get("dec_deg", 0)[0].get("value", 0)
-    print(f"Extracted RA: {ra}, Dec: {dec} for Aladin viewer.")
-
-    return generate_aladin_js(ra, dec)
-
-
-def generate_aladin_js(ra, dec):
-    """v3 compliant Aladin initialization."""
-    print(f"Generating Aladin JS for RA: {ra}, Dec: {dec}")
-    return f"""
-// Clear the div first to prevent the 'Multiple Instance' loop
-document.getElementById('aladin-lite-div').innerHTML = '';
-
-// v3 requires the .then() wrapper
-A.init.then(() => {{
-    var aladin = A.aladin('#aladin-lite-div', {{
-        survey: 'P/PanSTARRS/DR1/color-z-zg-g', // v3 uses different survey ID format
-        fov: 0.025,
-        target: '{ra} {dec}',
-        reticleColor: '#ff89ff',
-        reticleSize: 32,
-    }});
-
-    // Add your catalogs here...
-}});
-"""
 
 
 def fetch_api_data(endpoint, object_id, token, logger):
@@ -238,7 +242,9 @@ def get_metadata_data(object_id, token, logger):
 
     if response.status_code == 200:
         try:
-            data = MetadataResponseModel.model_validate_json(response.text, strict=False)
+            data = MetadataResponseModel.model_validate_json(
+                response.text, strict=False
+            )
             return data.model_dump()
         except ValidationError as e:
             logger.exception(e)
@@ -310,7 +316,9 @@ def perform_search(object_id, token, logger):
             None,
         )
     except Exception as e:
-        logger.error({"error": f"Unexpected error fetching metadata for {object_id}: {str(e)}"})
+        logger.error(
+            {"error": f"Unexpected error fetching metadata for {object_id}: {str(e)}"}
+        )
         logger.exception(e)
         return (
             html.Div(),

--- a/uv.lock
+++ b/uv.lock
@@ -2970,7 +2970,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "skypatrol" },
-    { name = "visdcc" },
     { name = "werkzeug" },
 ]
 
@@ -3014,7 +3013,6 @@ requires-dist = [
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "skypatrol" },
-    { name = "visdcc" },
     { name = "werkzeug" },
 ]
 provides-extras = ["dev"]
@@ -3225,18 +3223,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "visdcc"
-version = "0.0.63"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/71/2f9ecfafb138e4dd776c6ee95020d3125262dc46a58525a83a7b9337a591/visdcc-0.0.63.tar.gz", hash = "sha256:3c11b24f3a63060b90fa40b260aa7296329ae46f7239cff20daa1b4f753f3400", size = 1770894, upload-time = "2025-03-20T08:54:06.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/af/cf2d4d57c55a14480ea83f1f609183b5ad877b322b1fbb8d8afc32a14355/visdcc-0.0.63-py3-none-any.whl", hash = "sha256:f4ac6f53ba1269a80c190f54395755af73a3cd537159d845f3be00d4501f4037", size = 1783369, upload-time = "2025-03-20T08:54:03.957Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #73.

New `clientside_callback()` waits for lightcurve plot to complete before loading the Aladin widget.
The lightcurve plot now loads every time - tested on Chrome, Firefox and Safari.