### PR TITLE
UI Redesign

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+# Publishes the design mockups in mockups/ to GitHub Pages, so they can be
+# shared by link rather than checked out and opened locally.
+#
+# One-time setup: Settings -> Pages -> Source -> "GitHub Actions". The default
+# `github-pages` environment also restricts deployments to the default branch,
+# so this only publishes once changes reach main.
+#
+# Site root is mockups/, so the index lands at https://tarxiv.github.io/tarxiv/
+name: Deploy mockups to Pages
+
+on:
+  push:
+    branches: [main, jl/ui-redsign]
+    paths:
+      - "mockups/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel a half-finished deployment; queue instead.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: mockups
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ name: Deploy mockups to Pages
 
 on:
   push:
-    branches: [main, jl/ui-redesign]
+    branches: [main]
     paths:
       - "mockups/**"
       - ".github/workflows/pages.yml"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ name: Deploy mockups to Pages
 
 on:
   push:
-    branches: [main, jl/ui-redsign]
+    branches: [main, jl/ui-redesign]
     paths:
       - "mockups/**"
       - ".github/workflows/pages.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ aux/my_cred_file.json
 # vscode settings
 .vscode/
 *.code-workspace
+
+# Agents
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,14 @@
 ## Local Services
 - Full local stack lives under `setup/`. Start from `setup/.env.sample` copied to `setup/.env`.
 - Compose startup order matters for local integration: run `docker compose run setup_elasticsearch` before bringing up the main services.
+- A bare `docker compose up` starts only the backing stores (elasticsearch, couchbase, postgres, redis). Everything else is behind a profile: `logging` (logstash, kibana), `kafka` (broker, schema registry, connect, rest proxy, kafbat-ui, prometheus), `monitoring` (prometheus), `tools` (adminer), `tarxiv` (migrate, api, dashboard), `proxy` (nginx). Naming a service on the command line auto-enables its profile.
 - Couchbase bootstrap is slow enough that CI explicitly waits for the pipeline user to exist before loading data or starting the app.
 - Local Docker on macOS may need significantly more memory; `setup/README.md` calls out up to 12 GB.
 - Useful integration sequence from CI:
   - `docker compose run setup_elasticsearch`
   - `docker compose up -d elasticsearch logstash kibana couchbase`
   - `uv run --env-file setup/.env scripts/db_utils.py -l -f setup/example_dataset.json`
+  - `docker compose run --rm tarxiv-migrate`
   - `docker compose up -d tarxiv-api tarxiv-dashboard`
 
 ## Tests

--- a/bin/forced-phot
+++ b/bin/forced-phot
@@ -7,42 +7,88 @@ import argparse
 
 
 # Get config dir from arguments
-parser = argparse.ArgumentParser('forced-phot',
-                                 description="Script for controlling forced phot submissions and queues")
-parser.add_argument('--debug', action='store_true', default=False,
-                         help='set to enable printing/logging in debug mode')
+parser = argparse.ArgumentParser(
+    "forced-phot",
+    description="Script for controlling forced phot submissions and queues",
+)
+parser.add_argument(
+    "--debug",
+    action="store_true",
+    default=False,
+    help="set to enable printing/logging in debug mode",
+)
 module_subparsers = parser.add_subparsers(title="command", dest="command")
 
-queue = module_subparsers.add_parser("queue", help="start a forced phot queue",
-                             description="Start a multithreaded forced photometry queue to handle jobs")
-queue.add_argument("-n", "--n_workers", type=int, default=1,
-                   help="number of worker threads to run forced phot jobs")
-queue.add_argument("survey_name", type=str, choices=["atlas"],
-                   help="which forced phot survey to queue jobs")
-queue.add_argument("queue_type", type=str, choices=["alerts", "bulk"],
-                   help="Type of queue to run for forced phot")
+queue = module_subparsers.add_parser(
+    "queue",
+    help="start a forced phot queue",
+    description="Start a multithreaded forced photometry queue to handle jobs",
+)
+queue.add_argument(
+    "-n",
+    "--n_workers",
+    type=int,
+    default=1,
+    help="number of worker threads to run forced phot jobs",
+)
+queue.add_argument(
+    "survey_name",
+    type=str,
+    choices=["atlas"],
+    help="which forced phot survey to queue jobs",
+)
+queue.add_argument(
+    "queue_type",
+    type=str,
+    choices=["alerts", "bulk"],
+    help="Type of queue to run for forced phot",
+)
 
-submit = module_subparsers.add_parser("submit-single", help="submit forced phot job to the queue",
-                                      description="Submit single object that needs to append forced phot")
-submit.add_argument("survey_name", type=str, choices=["atlas"],
-                    help="which forced phot survey to request")
-submit.add_argument("queue_type", type=str, choices=["alerts", "bulk"],
-                   help="Type of queue to run for forced phot")
-submit.add_argument("source_id", type=str,
-                    help="source id that needs forced photometry (e.g. tns id or x-match tarxiv_id")
+submit = module_subparsers.add_parser(
+    "submit-single",
+    help="submit forced phot job to the queue",
+    description="Submit single object that needs to append forced phot",
+)
+submit.add_argument(
+    "survey_name",
+    type=str,
+    choices=["atlas"],
+    help="which forced phot survey to request",
+)
+submit.add_argument(
+    "queue_type",
+    type=str,
+    choices=["alerts", "bulk"],
+    help="Type of queue to run for forced phot",
+)
+submit.add_argument(
+    "source_id",
+    type=str,
+    help="source id that needs forced photometry (e.g. tns id or x-match tarxiv_id",
+)
 
-run = module_subparsers.add_parser("run-single", help="run forced phot job immediately",
-                                      description="Run forced phot on a single object and append to lightcurve")
-run.add_argument("survey_name", type=str, choices=["atlas"],
-                    help="which forced phot survey to request")
-run.add_argument("source_id", type=str,
-                    help="source id that needs forced photometry (e.g. tns id or x-match tarxiv_id")
+run = module_subparsers.add_parser(
+    "run-single",
+    help="run forced phot job immediately",
+    description="Run forced phot on a single object and append to lightcurve",
+)
+run.add_argument(
+    "survey_name",
+    type=str,
+    choices=["atlas"],
+    help="which forced phot survey to request",
+)
+run.add_argument(
+    "source_id",
+    type=str,
+    help="source id that needs forced photometry (e.g. tns id or x-match tarxiv_id",
+)
 
 args = parser.parse_args()
 
 
 # ALl same reporting mode
-reporting_mode = (PRINT | LOGFILE | DATABASE)
+reporting_mode = PRINT | LOGFILE | DATABASE
 if args.command == "queue":
     # Worker list to hold processes
     worker_list = []
@@ -50,9 +96,9 @@ if args.command == "queue":
 
     # Define a function to multiprocess our phot queue
     def start_worker(survey_name, worker_id, stop_event, reporting_mode, debug):
-        worker = ForcedPhotWorker(script_name="forced_phot_queue",
-                                  reporting_mode=reporting_mode,
-                                  debug=debug)
+        worker = ForcedPhotWorker(
+            script_name="forced_phot_queue", reporting_mode=reporting_mode, debug=debug
+        )
         worker.run_pipeline(survey_name, args.queue_type, worker_id, stop_event)
 
     # Signal to exit gracefully
@@ -64,7 +110,10 @@ if args.command == "queue":
     signal.signal(signal.SIGTERM, signal_handler)
     # Start workers
     for idx in range(args.n_workers):
-        p = mp.Process(target=start_worker, args=(args.survey_name, idx, stop_event, reporting_mode, args.debug))
+        p = mp.Process(
+            target=start_worker,
+            args=(args.survey_name, idx, stop_event, reporting_mode, args.debug),
+        )
         p.start()
         worker_list.append(p)
 
@@ -77,9 +126,11 @@ if args.command == "queue":
 
 elif args.command == "submit-single":
     # Create a utility and submit a single phot job
-    phot_util = ForcedPhotPipelineUtil(script_name="forced_phot_submit",
-                                       reporting_mode=reporting_mode,
-                                       debug=args.debug)
+    phot_util = ForcedPhotPipelineUtil(
+        script_name="forced_phot_submit",
+        reporting_mode=reporting_mode,
+        debug=args.debug,
+    )
     # Get tarxiv id for source
     txv_id = phot_util.db.get_source_txv_id(args.source_id)
     if txv_id is None:
@@ -89,9 +140,9 @@ elif args.command == "submit-single":
 
 elif args.command == "run-single":
     # Create the forced phot worker
-    worker = ForcedPhotWorker(script_name="forced_phot_run",
-                              reporting_mode=reporting_mode,
-                              debug=args.debug)
+    worker = ForcedPhotWorker(
+        script_name="forced_phot_run", reporting_mode=reporting_mode, debug=args.debug
+    )
     txv_id = worker.db.get_source_txv_id(args.source_id)
     if txv_id is None:
         print("NO SUCH OBJECT IN OUR DATABASE")
@@ -101,4 +152,3 @@ elif args.command == "run-single":
 
 else:
     print("Invalid command")
-

--- a/bin/kafka-admin
+++ b/bin/kafka-admin
@@ -14,26 +14,35 @@ group.add_argument("-d", "--delete", type=str, help="delete kafka topic")
 group.add_argument("-c", "--create", type=str, help="create kafka topic")
 group.add_argument("-l", "--list", action="store_true", help="list kafka topics")
 group.add_argument("-e", "--explain", type=str, help="explain/describe kafka topic")
-parser.add_argument("-p", "--partitions", type=int, default=16,
-                    help="number of partitions for new topic")
-parser.add_argument("-r", "--replication", type=int, default=1,
-                    help="replication factor for new topic")
+parser.add_argument(
+    "-p",
+    "--partitions",
+    type=int,
+    default=16,
+    help="number of partitions for new topic",
+)
+parser.add_argument(
+    "-r", "--replication", type=int, default=1, help="replication factor for new topic"
+)
 parser.add_argument("-t", "--topic", type=str, help="kafka topic name (for submission)")
 args = parser.parse_args()
 
 # Connect to kafka server
 kafka_host = os.environ["TARXIV_KAFKA_HOST"]
 admin_client_config = {
-    'bootstrap.servers': f"{kafka_host}:9092",}
+    "bootstrap.servers": f"{kafka_host}:9092",
+}
 admin_client = AdminClient(admin_client_config)
 
 if args.submit:
     # Get producer
-    conf = {'bootstrap.servers': os.environ["TARXIV_KAFKA_HOST"],
-            'queue.buffering.max.messages': 1000,
-            'queue.buffering.max.ms': 5000,
-            'batch.num.messages': 16,
-            'client.id': "cmdline"}
+    conf = {
+        "bootstrap.servers": os.environ["TARXIV_KAFKA_HOST"],
+        "queue.buffering.max.messages": 1000,
+        "queue.buffering.max.ms": 5000,
+        "batch.num.messages": 16,
+        "client.id": "cmdline",
+    }
     producer = Producer(conf)
 
     # Read in json file
@@ -41,7 +50,7 @@ if args.submit:
         json_data = json.load(f)
 
     # Either submit list or single dict
-    if type(json_data) == list:
+    if isinstance(json_data, list):
         for item in json_data:
             # Submit
             producer.produce(topic=args.topic, value=json.dumps(item).encode("utf-8"))
@@ -64,26 +73,30 @@ elif args.list:
 elif args.delete:
     print("DELETING")
     futures = admin_client.delete_topics([args.delete])
-    for topic, future in futures.items():
+    for future in futures.values():
         future.result()
 
 
 elif args.create:
     print("CREATING")
-    new = NewTopic(args.create, num_partitions=args.partitions, replication_factor=args.replication)
+    new = NewTopic(
+        args.create, num_partitions=args.partitions, replication_factor=args.replication
+    )
     futures = admin_client.create_topics([new])
-    for topic, future in futures.items():
+    for future in futures.values():
         future.result()
 
 elif args.explain:
-    conf = {'bootstrap.servers': f"{kafka_host}:9092",
-            'group.id': 'testing1',
-            'auto.offset.reset': 'smallest',
-            'enable.auto.commit': True,
-            'max.poll.interval.ms': 10000,
-            'session.timeout.ms': 10000,
-            'heartbeat.interval.ms': 3000,
-            'enable.partition.eof': False}
+    conf = {
+        "bootstrap.servers": f"{kafka_host}:9092",
+        "group.id": "testing1",
+        "auto.offset.reset": "smallest",
+        "enable.auto.commit": True,
+        "max.poll.interval.ms": 10000,
+        "session.timeout.ms": 10000,
+        "heartbeat.interval.ms": 3000,
+        "enable.partition.eof": False,
+    }
     consumer = Consumer(conf)
     try:
         topic_name = args.explain
@@ -100,7 +113,9 @@ elif args.explain:
         topic_partitions = [_TopicPartition(topic_name, p) for p in partitions]
 
         print(f"--- Topic: {topic_name} ---")
-        print(f"{'Partition':<10} | {'Low Offset':<12} | {'High Offset':<12} | {'Message Count':<15}")
+        print(
+            f"{'Partition':<10} | {'Low Offset':<12} | {'High Offset':<12} | {'Message Count':<15}"
+        )
 
         for tp in topic_partitions:
             # Get the low (earliest) and high (latest/log end) offsets
@@ -108,7 +123,9 @@ elif args.explain:
                 # get_watermark_offsets gets the earliest and latest offset
                 low_offset, high_offset = consumer.get_watermark_offsets(tp, timeout=5)
                 message_count = max(0, high_offset - low_offset)
-                print(f"{tp.partition:<10} | {low_offset:<12} | {high_offset:<12} | {message_count:<15}")
+                print(
+                    f"{tp.partition:<10} | {low_offset:<12} | {high_offset:<12} | {message_count:<15}"
+                )
             except KafkaException as e:
                 print(f"{tp.partition:<10} | Error getting offsets: {e}")
 

--- a/bin/start-api
+++ b/bin/start-api
@@ -2,6 +2,7 @@
 from tarxiv.utils import PRINT, LOGFILE, DATABASE
 from tarxiv.api import API
 import argparse
+import os
 
 
 # Get config dir from arguments
@@ -9,10 +10,15 @@ parser = argparse.ArgumentParser('start-api',
                                  description="Run TarXiv Flask API")
 parser.add_argument('--debug', action='store_true', default=False,
                          help='set to enable printing/logging in debug mode')
+parser.add_argument('--reporting-mode',
+              type=int,
+              default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
+              choices=[0, 1, 2, 3, 4, 5, 6, 7],
+              help='bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)')
 args = parser.parse_args()
 
 # Get API object and start server
 txv_api = API(script_name="tarxiv_api",
-              reporting_mode=(PRINT | LOGFILE | DATABASE),
+          reporting_mode=args.reporting_mode,
               debug=args.debug)
 txv_api.start_server()

--- a/bin/start-api
+++ b/bin/start-api
@@ -6,19 +6,24 @@ import os
 
 
 # Get config dir from arguments
-parser = argparse.ArgumentParser('start-api',
-                                 description="Run TarXiv Flask API")
-parser.add_argument('--debug', action='store_true', default=False,
-                         help='set to enable printing/logging in debug mode')
-parser.add_argument('--reporting-mode',
-              type=int,
-              default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
-              choices=[0, 1, 2, 3, 4, 5, 6, 7],
-              help='bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)')
+parser = argparse.ArgumentParser("start-api", description="Run TarXiv Flask API")
+parser.add_argument(
+    "--debug",
+    action="store_true",
+    default=False,
+    help="set to enable printing/logging in debug mode",
+)
+parser.add_argument(
+    "--reporting-mode",
+    type=int,
+    default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
+    choices=[0, 1, 2, 3, 4, 5, 6, 7],
+    help="bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)",
+)
 args = parser.parse_args()
 
 # Get API object and start server
-txv_api = API(script_name="tarxiv_api",
-          reporting_mode=args.reporting_mode,
-              debug=args.debug)
+txv_api = API(
+    script_name="tarxiv_api", reporting_mode=args.reporting_mode, debug=args.debug
+)
 txv_api.start_server()

--- a/bin/tns-ingest
+++ b/bin/tns-ingest
@@ -94,7 +94,7 @@ elif args.command == "alert_queue":
         debug=args.debug,
     )
     # Run the pipeline
-    txv_tns.run_pipeline(topic="internal_tns_alerts")
+    txv_tns.run_pipeline(topic="tns_alerts")
 
 elif args.command == "bulk_queue":
     txv_tns = TNSPipeline(
@@ -103,7 +103,7 @@ elif args.command == "bulk_queue":
         debug=args.debug,
     )
     # Run the pipeline
-    txv_tns.run_pipeline(topic="internal_tns_bulk")
+    txv_tns.run_pipeline(topic="tns_bulk")
 
 elif args.command == "update_queue":
     txv_tns = TNSPipeline(
@@ -112,7 +112,7 @@ elif args.command == "update_queue":
         debug=args.debug,
     )
     # Run the pipeline
-    txv_tns.run_pipeline(topic="internal_tns_bulk")
+    txv_tns.run_pipeline(topic="tns_updates")
 
 elif args.command == "bulk_submit":
     txv_tns = TNSPipeline(

--- a/bin/tns-ingest
+++ b/bin/tns-ingest
@@ -6,79 +6,120 @@ import datetime
 import argparse
 import os
 
-#from pandas.errors import SettingWithCopyWarning # Location may vary by pandas version
-#warnings.simplefilter(action='ignore', category=SettingWithCopyWarning)
+# from pandas.errors import SettingWithCopyWarning # Location may vary by pandas version
+# warnings.simplefilter(action='ignore', category=SettingWithCopyWarning)
 
 # Get config dir from arguments
-parser = argparse.ArgumentParser('tns-ingest',
-                                 description="TarXiv TNS Alert ingestion. "
-                                        "Monitor new TNS alerts, and query relevant data into database.'")
-parser.add_argument('--debug', action='store_true', default=False,
-                         help='set to enable printing/logging in debug mode')
-parser.add_argument('--reporting-mode',
-              type=int,
-              default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
-              choices=[0, 1, 2, 3, 4, 5, 6, 7],
-              help='bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)')
+parser = argparse.ArgumentParser(
+    "tns-ingest",
+    description="TarXiv TNS Alert ingestion. "
+    "Monitor new TNS alerts, and query relevant data into database.'",
+)
+parser.add_argument(
+    "--debug",
+    action="store_true",
+    default=False,
+    help="set to enable printing/logging in debug mode",
+)
+parser.add_argument(
+    "--reporting-mode",
+    type=int,
+    default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
+    choices=[0, 1, 2, 3, 4, 5, 6, 7],
+    help="bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)",
+)
 module_subparsers = parser.add_subparsers(title="command", dest="command")
-module_subparsers.add_parser("email", help="Turn on email monitor",
-                             description="Watch email for new TNS alerts and submit to internal queue")
-module_subparsers.add_parser("alert_queue", help="Process objects to internal alert queue",
-                             description="Watch internal queue (from TNS emails) and submit new alerts.")
-module_subparsers.add_parser("bulk_queue", help="Process objects submitted to internal bulk queue",
-                             description="Watch internal queue (from bulk commands) and submit objects.")
-module_subparsers.add_parser("update_queue", help="Process objects submitted to internal update queue",
-                             description="Watch internal queue (from bulk commands) and update objects.")
-bulk = module_subparsers.add_parser("bulk_submit", help="Submit bulk updates or re-compute for TNS objects",
-                                    description="Submit bulk updates or re-compute for TNS objects.")
-bulk.add_argument("--all", action="store_true",
-                  help="Pull all TNS objects and re-upsert everything")
-bulk.add_argument("--missing", action="store_true",
-                  help="Pull all missing TNS updates and upsert")
-bulk.add_argument("--active", action="store_true",
-                  help="Pull data for all current active objects and update")
-bulk.add_argument("--data_source", type=str,
-                  help="Add or update a new data source to all objects")
-single = module_subparsers.add_parser("run_single", help="pull, process, and upsert a single TNS object",
-                             description="Take in a single TNS object id, and ingest")
-single.add_argument("tns_id", type=str,
-                    help="TNS object id (e.g. 2026abcd)")
+module_subparsers.add_parser(
+    "email",
+    help="Turn on email monitor",
+    description="Watch email for new TNS alerts and submit to internal queue",
+)
+module_subparsers.add_parser(
+    "alert_queue",
+    help="Process objects to internal alert queue",
+    description="Watch internal queue (from TNS emails) and submit new alerts.",
+)
+module_subparsers.add_parser(
+    "bulk_queue",
+    help="Process objects submitted to internal bulk queue",
+    description="Watch internal queue (from bulk commands) and submit objects.",
+)
+module_subparsers.add_parser(
+    "update_queue",
+    help="Process objects submitted to internal update queue",
+    description="Watch internal queue (from bulk commands) and update objects.",
+)
+bulk = module_subparsers.add_parser(
+    "bulk_submit",
+    help="Submit bulk updates or re-compute for TNS objects",
+    description="Submit bulk updates or re-compute for TNS objects.",
+)
+bulk.add_argument(
+    "--all", action="store_true", help="Pull all TNS objects and re-upsert everything"
+)
+bulk.add_argument(
+    "--missing", action="store_true", help="Pull all missing TNS updates and upsert"
+)
+bulk.add_argument(
+    "--active",
+    action="store_true",
+    help="Pull data for all current active objects and update",
+)
+bulk.add_argument(
+    "--data_source", type=str, help="Add or update a new data source to all objects"
+)
+single = module_subparsers.add_parser(
+    "run_single",
+    help="pull, process, and upsert a single TNS object",
+    description="Take in a single TNS object id, and ingest",
+)
+single.add_argument("tns_id", type=str, help="TNS object id (e.g. 2026abcd)")
 args = parser.parse_args()
 
 
 # Create survey objects
 if args.command == "email":
-    tns_mail = IMAP(script_name="tns_email_watch",
-                   reporting_mode=args.reporting_mode,
-                   debug=args.debug)
+    tns_mail = IMAP(
+        script_name="tns_email_watch",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     # Run the pipeline
     tns_mail.monitor_notices()
 
 elif args.command == "alert_queue":
-    txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=args.reporting_mode,
-                          debug=args.debug)
+    txv_tns = TNSPipeline(
+        script_name="tns_missing_ingest",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_alerts")
 
 elif args.command == "bulk_queue":
-    txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=args.reporting_mode,
-                          debug=args.debug)
+    txv_tns = TNSPipeline(
+        script_name="tns_missing_ingest",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_bulk")
 
 elif args.command == "update_queue":
-    txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=args.reporting_mode,
-                          debug=args.debug)
+    txv_tns = TNSPipeline(
+        script_name="tns_missing_ingest",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_bulk")
 
 elif args.command == "bulk_submit":
-    txv_tns = TNSPipeline(script_name="tns_daily_ingest",
-                          reporting_mode=args.reporting_mode,
-                          debug=args.debug)
+    txv_tns = TNSPipeline(
+        script_name="tns_daily_ingest",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     if args.all:
         txv_tns.update_bulk(include_existing=True)
     elif args.missing:
@@ -91,9 +132,11 @@ elif args.command == "bulk_submit":
         print("Invalid bulk submission option")
 
 elif args.command == "run_single":
-    txv_tns = TNSPipeline(script_name="tns_single_ingest",
-                          reporting_mode=args.reporting_mode,
-                          debug=args.debug)
+    txv_tns = TNSPipeline(
+        script_name="tns_single_ingest",
+        reporting_mode=args.reporting_mode,
+        debug=args.debug,
+    )
     # Get survey information
     txv_id, obj_meta, obj_lc = txv_tns.get_object(args.tns_id)
     # Get timestamp

--- a/bin/tns-ingest
+++ b/bin/tns-ingest
@@ -4,6 +4,7 @@ from tarxiv.pipeline import TNSPipeline
 from tarxiv.alerts import IMAP
 import datetime
 import argparse
+import os
 
 #from pandas.errors import SettingWithCopyWarning # Location may vary by pandas version
 #warnings.simplefilter(action='ignore', category=SettingWithCopyWarning)
@@ -14,6 +15,11 @@ parser = argparse.ArgumentParser('tns-ingest',
                                         "Monitor new TNS alerts, and query relevant data into database.'")
 parser.add_argument('--debug', action='store_true', default=False,
                          help='set to enable printing/logging in debug mode')
+parser.add_argument('--reporting-mode',
+              type=int,
+              default=int(os.getenv("TARXIV_REPORTING_MODE", (PRINT | LOGFILE | DATABASE))),
+              choices=[0, 1, 2, 3, 4, 5, 6, 7],
+              help='bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE (default: TARXIV_REPORTING_MODE or 7)')
 module_subparsers = parser.add_subparsers(title="command", dest="command")
 module_subparsers.add_parser("email", help="Turn on email monitor",
                              description="Watch email for new TNS alerts and submit to internal queue")
@@ -43,35 +49,35 @@ args = parser.parse_args()
 # Create survey objects
 if args.command == "email":
     tns_mail = IMAP(script_name="tns_email_watch",
-                   reporting_mode=(PRINT | LOGFILE | DATABASE),
+                   reporting_mode=args.reporting_mode,
                    debug=args.debug)
     # Run the pipeline
     tns_mail.monitor_notices()
 
 elif args.command == "alert_queue":
     txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=(PRINT | LOGFILE | DATABASE),
+                          reporting_mode=args.reporting_mode,
                           debug=args.debug)
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_alerts")
 
 elif args.command == "bulk_queue":
     txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=(PRINT | LOGFILE | DATABASE),
+                          reporting_mode=args.reporting_mode,
                           debug=args.debug)
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_bulk")
 
 elif args.command == "update_queue":
     txv_tns = TNSPipeline(script_name="tns_missing_ingest",
-                          reporting_mode=(PRINT | LOGFILE | DATABASE),
+                          reporting_mode=args.reporting_mode,
                           debug=args.debug)
     # Run the pipeline
     txv_tns.run_pipeline(topic="internal_tns_bulk")
 
 elif args.command == "bulk_submit":
     txv_tns = TNSPipeline(script_name="tns_daily_ingest",
-                          reporting_mode=(PRINT | LOGFILE | DATABASE),
+                          reporting_mode=args.reporting_mode,
                           debug=args.debug)
     if args.all:
         txv_tns.update_bulk(include_existing=True)
@@ -86,7 +92,7 @@ elif args.command == "bulk_submit":
 
 elif args.command == "run_single":
     txv_tns = TNSPipeline(script_name="tns_single_ingest",
-                          reporting_mode=(PRINT | LOGFILE | DATABASE),
+                          reporting_mode=args.reporting_mode,
                           debug=args.debug)
     # Get survey information
     txv_id, obj_meta, obj_lc = txv_tns.get_object(args.tns_id)

--- a/docs/dev-notes/lightcurve-polish-todo.md
+++ b/docs/dev-notes/lightcurve-polish-todo.md
@@ -1,0 +1,106 @@
+# Object page polish — round 2
+
+**Date:** 2026-08-10
+**Follows:** [`lightcurve-redesign-plan.md`](./lightcurve-redesign-plan.md) (the balanced-layout redesign; shipped)
+
+Review notes from running the redesigned page under Compose, checked against
+`mockups/mockup-2-balanced.html`. Each item below is a discrete change.
+
+> **Doc convention.** This is a new file rather than an edit to the redesign
+> plan. That plan records what was decided and shipped in the previous round;
+> rewriting it would destroy that history and grow one doc past the point where
+> an agent can hold it in context. Keep rounds in separate dated, cross-linked
+> files.
+
+## Two bugs found in the path of this work
+
+- **Tag colours never render.** `render_tagging_panel` passed
+  `color=(tag["color"] or "gray").lstrip("#")` into `dmc.Badge`'s *named-colour*
+  prop, so `#4287f5` arrived as `4287f5`, which is not a Mantine palette key.
+  The same markup (and bug) was duplicated in `pages/user.py::tag_section`.
+- **Stale status text.** `search-status` was set to
+  `"Searching for object: {id}"` and never cleared, so it still read
+  "Searching…" after a successful load.
+
+## Todo
+
+- [x] **1. Off-white background.** Tokens were already right
+      (`--tarxiv-bg: #f7f7f8`); Mantine's own body rule won the cascade and
+      painted `#ffffff`. Set `bg="var(--tarxiv-bg)"` on the `dmc.AppShell` and
+      add a `:root[data-mantine-color-scheme] body` rule to `_STATIC_CSS` so it
+      outranks a bare `body` selector regardless of stylesheet order. Verify via
+      computed style, not by eye.
+- [x] **2. Card header icons.** `icon` parameter on `expressive_card`, rendered
+      before the title in `.tarxiv-card-head` at `var(--tarxiv-ink-3)` to match
+      `.card-head h2 svg` in the mockup. Lightcurve `clarity:curve-chart-line`,
+      Sky view `mdi:earth`, Source metadata `mdi:table`, Citations
+      `mdi:format-quote-close`, Tags `mdi:tag-outline`, JSON `mdi:code-json`.
+- [x] **3. Shared `tag_badge` helper** in `components/cards.py`, passing the raw
+      hex through as a CSS colour. Adopt in `render_tagging_panel` and
+      `pages/user.py::tag_section` — fixes the colour bug in both and removes
+      the duplication.
+- [x] **4. Tag card layout.** Assigned tags become a compact wrapping row of
+      chips *above* the select + assign row, replacing the stack of full-width
+      bordered `Paper` rows. Keep the pattern-matching remove ids. Card gains
+      `id="object-tag-card"` (scroll target) and the tag icon.
+- [x] **5. Page head.** Drop the duplicated search controls; add a prominent
+      `+ Tag` button and a `Cite` clipboard button. Read-only tag chips sit
+      after the object-type badge in `html.Div(id="object-tag-chips")`.
+      `_search_controls` stays — still used by the empty state.
+- [x] **6. Populate head chips.** Server-render via the existing
+      `fetch_object_tags` in `perform_search`, threaded through
+      `format_object_metadata` → `build_page_head`. Keep live by adding a chips
+      Output to `handle_assign_object_tag` / `handle_remove_object_tag` **only**
+      — *not* to `load_object_tagging_panel`, which runs on the empty page where
+      no head exists (the trap the `object-tagging-container` test guards).
+- [x] **7. Drop the success banner** and clear the status text on success.
+      Error/warning banners and the `message-banner` Box stay — `cone.py` also
+      writes to that id.
+- [x] **8. Centred content column** at `max-width: 1380px` inside
+      `AppShellMain`, matching the mockup's `.container`. Topbar stays
+      full-bleed.
+- [x] **9. Scroll-to-tags.** New `assets/object_page.js` under the
+      `window.dash_clientside.object_page` namespace (inline callback strings
+      are unreliable under Dash 4 — see the comment in `lightcurve.py`).
+      Smooth-scroll, focus the select, brief highlight.
+
+### Done along the way
+
+- [x] Tag badges no longer shout — Mantine upper-cases badges by default, which
+      reads badly for user-authored tag names (`tt="none"`).
+- [x] The JSON accordion icon is inline with its label; `AccordionControl`'s own
+      `icon` prop renders at the far end of the row.
+- [x] `handle_assign_object_tag` now logs a warning on a failed POST instead of
+      silently re-rendering an unchanged panel, which looked like a no-op.
+
+### Deferred / optional
+
+- [ ] Surface that assign failure in the UI. `object-tagging-banner` exists in
+      the panel but is still never written to — a user-visible message needs an
+      extra Output on the assign callback.
+- [ ] `api_base_url()` is duplicated verbatim between `lightcurve.py` and
+      `tagged.py`; `fetch_api_data` still carries a "refactor to a shared API
+      client" TODO.
+- [ ] `dmc.ActionIcon` (2.6.0) rejects `title`; this has now bitten twice. If a
+      third instance appears, add a lint rule or a helper wrapper.
+
+## Verification — done
+
+- 210 tests pass (201 at the start of this round, +9). New assertions:
+  `tag_badge` keeps the `#` and falls back to gray; `build_tag_chips` renders
+  one badge per assignment; `build_page_head` has `jump-to-tags`/`cite-copy`/
+  `object-tag-chips` and no `object-id-input`; the tagging panel keeps
+  `object-tag-card` and its pattern-matching remove ids.
+- `ruff check` and `ruff format` clean.
+- Verified in-browser against a harness that renders the **real** shell from
+  `create_layout()` with the object page injected into its `page-content` slot,
+  rather than rebuilding the shell (the substitution that hid the `visibleFrom`
+  bug last round). Confirmed by computed style, not by eye:
+  `body` = `rgb(247,247,248)` on `#ffffff` cards; content column capped at
+  1380px; dark mode `rgb(18,22,23)`. Also confirmed: icons on all six cards,
+  four tag chips on one line above the select, correct tag colours in both
+  schemes, +Tag scrolling the card into view with the select focused.
+
+**Not verified:** the live API round trip (assign/remove actually updating the
+head chips, and the Cite button copying) needs the Compose stack — the harness
+has no API behind it.

--- a/docs/dev-notes/lightcurve-redesign-plan.md
+++ b/docs/dev-notes/lightcurve-redesign-plan.md
@@ -1,0 +1,102 @@
+# Implement "Balanced" Lightcurve Page Redesign in Dash
+
+## Context
+
+The mockup phase produced four standalone HTML prototypes in `mockups/`; Jack approved **mockup 2 — balanced** (`mockups/mockup-2-balanced.html`, tokens in `mockups/shared.css`, widget logic in `mockups/shared.js`). This plan implements it in the real app (`tarxiv/dashboard/`, Dash 4.0.0 + dash-mantine-components 2.6.0).
+
+Decisions confirmed with Jack:
+- **Topbar app-wide**: replace the 100px left icon rail with a slim 52px top navbar on every page.
+- **App-wide design system**: new tokens (Inter/JetBrains Mono, 14px bordered cards, real red ramp) via shared components; other pages keep their layouts.
+- **Plot ⇄ Table toggle** on the lightcurve card (also the a11y relief channel for the amber filter colour).
+- **Compact search row** in the page head; centred search card as the empty state.
+
+The mockups stay untracked reference material; `mockups/shared.css`/`shared.js` are the source of truth for token values, the validated filter palette, and the Plotly layout spec.
+
+## Status: implemented
+
+All six phases are done; 194 tests pass and `ruff check` is clean. Two things changed from the plan below during implementation — both deliberate:
+
+1. **`format_object_metadata` returns a 4-tuple**, `(results_top, metadata_card, citations_card, full_metadata)`, and takes a new `lc_data` argument. The balanced lower grid pairs the metadata card with the tagging container, and the tagging container must stay in the base layout (its callbacks fire on initial load), so the metadata card has to be handed back separately. The two test unpack sites were updated; every id assertion is unchanged.
+2. **Marker symbol encodes the band, not the survey.** The plan had symbol carrying the survey, which left ZTF g and ZTF r both circles — and the green/red pair measures ΔE 6.9 under deuteranopia, inside the 6–8 band that is only legal *with* a secondary encoding. Shape therefore moves with hue instead. The consequence is that the same bandpass from two surveys renders identically; that is scientifically honest (it is the same measurement) and the legend groups plus the table view disambiguate.
+
+Palette validation (dataviz `validate_palette.js`, all-pairs/scatter pairlist, against `#ffffff` and `#1c2224`): the four bands that actually co-occur in TarXiv data — g, r, c, o — pass every gate in both schemes. Rarer bands (u, V, i, z, w) sit past the documented four-series all-pairs cap; all are inside the lightness band with chroma above the floor, and lean on symbol + legend + table for identity. Amber `o` and magenta `z` are sub-3:1 on the light surface, for which the Plot⇄Table toggle is the required relief channel.
+
+Not verified end-to-end: the dashboard needs Couchbase + the API, so the real `/lightcurve/<id>` round trip is untested. Verification used a standalone harness rendering the actual components with sample SN 2023ixf data — topbar, key facts, plot (both schemes), Plot⇄Table, Aladin, metadata tabs, citations, JSON accordion and footer all confirmed in light and dark at 1512×801 and 1280×800. Run the docker-compose dev stack for a live pass.
+
+## Phasing (6 commits, each runnable + tests green)
+
+### Phase 1 — Design tokens + theme foundation
+**`tarxiv/dashboard/styles.py`**
+- New `COLORS` = `{"primary": "#b31b1b", "light": {...}, "dark": {...}}` with the full token set from `mockups/shared.css` (bg, card, card_2, border, border_strong, ink/ink_2/ink_3, primary_hover, primary_ink — `#e06058` on dark, primary_soft/_2, grid, axis, shadow, shadow_lg).
+- `ARXIV_RED_RAMP` — real 10-step scale, index 6 = `#b31b1b`.
+- Replace `FILTER_COLORS` with `FILTER_STYLE` keyed by `(survey, filter)` — validated values from `mockups/shared.js`: `("ztf","g") #199e70 circle`, `("ztf","r") #e34948 square`, `("atlas","c") #2a78d6/#3987e5 diamond`, `("atlas","o") #eda100/#c98500 triangle-up` — plus `FILTER_FALLBACK` by filter only (u/g/c/V/r/o/i/z/w/Unknown, wavelength-ordered hues, light+dark, distinct symbols) and `resolve_filter_style(survey, filter)` (normalises survey lowercase, `"R"`→`"r"`; exact → filter fallback → Unknown). **Re-run the dataviz palette validator** on the fallback hexes vs `#ffffff`/`#1c2224`; symbols cover warn-band pairs, fix any fail-band pair.
+- Delete ~11 dead style dicts (NAVBAR/NAV_TITLE/NAV_RIGHT/USER_CHIP/LOGIN/SIGNUP/PROFILE_BUTTON/AUTH_MODAL_*/PROFILE_DRAWER_*). Keep + tokenise `CARD_STYLE` (cone); keep `AVATAR_STYLE(S)` (auth.py), `BUTTON_STYLE`+`ORCID_BUTTON_STYLE` (user.py).
+
+**`tarxiv/dashboard/components/theme_manager.py`**
+- `THEME`: `colors.arxiv_red = ARXIV_RED_RAMP`, `primaryShade {"light": 6, "dark": 5}`, `fontFamily` Inter stack, `fontFamilyMonospace` JetBrains Mono stack, `headings` (Inter, 700), `defaultRadius "md"`, component defaults (inputs/buttons `size="sm"`, `Paper {"radius": 14}`).
+- `generate_css()`: write path derived from `__file__` (fixes the cwd TODO at line ~126). Emit new `--tarxiv-*` vars per `:root[data-mantine-color-scheme=…]` by looping `COLORS["light"]/["dark"]`, **keep legacy aliases** (`--tarxiv-color-primary`, `--tarxiv-card-1`→card, `--tarxiv-surface-1/-2`→card_2, `--tarxiv-footer-bg`→`#1c2224` in both modes). Delete the `nav_hover` block; add static `.tarxiv-topnav-link` (+ `.active`), `.tarxiv-card-head`, `.tarxiv-wordmark` classes mirroring `mockups/shared.css`.
+- `register_tarxiv_templates()`: rebuild `tarxiv_light`/`tarxiv_dark` **from `COLORS`** mirroring `lightcurveLayout()` in `mockups/shared.js`: paper/plot bg = card colour (fixes the `#1A1B1E` dark mismatch), Inter font, tokenised grid/axis/tick styling, horizontal legend (x 0, y 1.02, grouptitlefont), inverted hoverlabel, margins l52/r12/t12/b42. **Do not rename the templates** — the strings double as `active-settings-store.theme` values.
+- Delete `get_filter_style` (only consumer was plots.py) + its `components/__init__.py` export.
+
+**`tarxiv/dashboard/app.py`**: add `external_stylesheets=[Google Fonts css2 Inter 400–700 + JetBrains Mono 400/600]`. (Accepted CDN dependency — Aladin already is one; self-host woff2 later if offline matters.)
+
+### Phase 2 — App shell: top navbar
+**`tarxiv/dashboard/layouts/main_layout.py`** (stores, cookie popup, auth, footer, `url`/`page-content` unchanged)
+- `dmc.AppShell(id="app-shell", header={"height": 52}, navbar={"width": 260, "breakpoint": "sm", "collapsed": {"mobile": True, "desktop": True}}, padding="md")` — drop `layout="alt"`.
+- `dmc.AppShellHeader` (all breakpoints): Burger (`hiddenFrom="sm"`) · wordmark `dcc.Link` ("tar" + red "X" + "iv") · `html.Div(id="topbar-nav", visibleFrom="sm")` · spacer · global search (`dash_extensions.Keyboard` wrapping `dmc.TextInput(id="global-search-input", w=220, size="xs")`, `id="global-search-keyboard"`, `visibleFrom="md"`) · theme toggle `dmc.ActionIcon(id="color-scheme-toggle", children=DashIconify(id="theme-icon", ...))` — **both ids preserved** so `style_callbacks.py` theme callbacks keep working · account avatar chip (adapt `account_nav_hovercard`, `position="bottom-end"`, keep `nav-logout-button`).
+- `dmc.AppShellNavbar` → mobile-only drawer with `html.Div(id="mobile-nav-content")`; nav clicks full-reload (`url` has `refresh=True`) so no close-callback needed.
+- Cleanup: `cookie_callbacks.py` imports `SETTING_DEFAULTS` from main_layout instead of duplicating; delete `create_nav_item`/`create_nav_link` from cards.py after re-grep for users.
+
+**`tarxiv/dashboard/callbacks/style_callbacks.py`**
+- Retarget `refresh_navigation` → `[Output("topbar-nav","children"), Output("mobile-nav-content","children")]`; topbar = `dcc.Link(className="tarxiv-topnav-link"...)`, mobile = `dmc.NavLink` with icons.
+- New `global_search` callback: `Output("url","pathname", allow_duplicate=True)`, `Input("global-search-keyboard","n_keydowns")`, `State("global-search-input","value")` → `/lightcurve/{value}`. Coexists with lightcurve's `search_navigation` (both allow_duplicate).
+- New burger callback: `Patch()` on `app-shell.navbar` → `["collapsed"]["mobile"] = not opened` (fixes currently-dead mobile burger).
+
+### Phase 3 — Shared component restyle
+**`tarxiv/dashboard/components/cards.py`**
+- `title_card` — same signature; compact left-aligned `dmc.Title(fz=26)` + dimmed subtitle (kills the 90px red banner on all 6 pages).
+- `expressive_card(children, title=None, title_order=2, header_extra=None, **kwargs)` — `dmc.Paper(radius=14, p=0, bg var(--tarxiv-card), border var(--tarxiv-border), boxShadow var(--tarxiv-shadow), overflow hidden)`; titled cards get a `.tarxiv-card-head` divider row (title fz13 fw600 + optional `header_extra`), body `dmc.Box(p="md")`. Merge caller `style`, don't clobber.
+- `footer_card` — keep dark strip via alias, `p="md"`, top border.
+- `create_message_banner` — replace hardcoded `color_map` with Mantine `dmc.Alert` colors (success→green, error→red, warning→yellow, info→blue), `variant="light"`; signature unchanged (~50 call sites untouched, dark mode fixed).
+- Spot-fix: `pages/user.py` ColorInput `swatches` from the new categorical hexes.
+
+### Phase 4 — Plot rebuild
+**`tarxiv/dashboard/components/plots.py`** — `create_lightcurve_plot` signature unchanged:
+- `scheme` from template name; `surface = COLORS[scheme]["card"]`; per group `style = resolve_filter_style(survey, filter)`, trace `name = f"{survey.upper()} {filter}"`.
+- Detections: symbol per style, `marker.line {width 1, color surface}`, `error_y {width 0, thickness 1.2, color}`, `customdata=errs`, hovertemplate `"<b>{label}</b>  MJD %{x:.2f}<br>%{y:.2f} ± %{customdata:.2f} mag<extra></extra>"` (no-± variant when no errors), `legendgroup=survey` + grouptitle.
+- Limits: `triangle-down-open`, size 9, opacity 0.55, `showlegend=False` (behaviour change from today — grouped legend + hover covers it), own hovertemplate.
+- Layout: no title (card head owns it), `height=430`, `xaxis tickformat "d"`, y reversed "Apparent magnitude"; legend/fonts/margins come from the new templates — don't repeat per-figure.
+- `empty_lightcurve_plot`: restyle only (height 430, no title); **keep the test contract**: 0 traces, hidden axes, exactly 1 translucent rect shape, centred annotation, default text `"No lightcurve data available"`, custom `message` honoured.
+
+### Phase 5 — Balanced lightcurve page
+**New `tarxiv/dashboard/components/object_view.py`** (all pure/unit-testable where possible):
+- `build_key_facts(meta, lc_data) -> list[dict]` — 6 facts `{label, value, unit}` with em-dash fallbacks. **Data gotchas (verified in pipeline code)**: host is under `tns["hostname"]` (not `host_name`), else `sherlock.catalogue_object_id`; redshift prefers `tns.redshift` over `sherlock.redshift`; peak mag = min across every source's `peak_mags` (plural) list where the magnitude value sits under the key **`"limit"`** (writer quirk in `data_sources.py::summarize_lc_mags`); distance from `sherlock.best_distance` (+" Mpc" when numeric); detections counted from `lc_data` (`detection==1`) with survey list as unit.
+- `build_page_head(object_id, meta)` — title + `dmc.Badge` type chip + `_build_coordinates_header` (keeps id `object-coordinates`) + spacer + compact search (`object-id-input`/`search-id-keyboard`/`search-id-button` ids kept → existing `search_navigation` callback untouched).
+- `build_summary_strip(facts)` — card-styled `dmc.SimpleGrid(cols={"base":2,"sm":3,"lg":6})`.
+- `build_hero_grid(object_id)` — Grid `span {base:12, lg:7}`: lightcurve card with `header_extra=dmc.SegmentedControl(id="lc-view-toggle", data=["Plot","Table"], size="xs")`, body `html.Div(id="lc-plot-wrap")` (Loading + `dcc.Graph(id={"type":"themeable-plot","index":"lightcurve-plot"}, style height 430, config responsive)`) + `html.Div(id="lc-table-wrap", style display none)`; `span {base:12, lg:5}`: Sky-view card with `aladin-status-dummy` + `aladin-lite-div` (430px).
+- `build_photometry_table(lc_data, scheme)` — `dmc.ScrollArea(h=430)` + `dmc.Table` sorted by MJD: MJD (mono) | Filter (colour swatch via `resolve_filter_style` + "SURVEY filter") | Mag (`"> {limit:.2f}"` for limits) | σ (dash for limits) | Type; `detection==-1` excluded.
+- `build_empty_search_state(prefill=None)` — centred search card (same search ids).
+
+**`cards.py::format_object_metadata`** — rewrite; **returns a 4-tuple** `(results_top, metadata_card, citations_card, full_metadata)` and gains `lc_data=None` param (the 3-tuple can't express the balanced lower grid, since `object-tagging-container` lives in the base layout — tests forbid it inside these pieces). `results_top` = page head + summary strip + hero grid; `metadata_card` = titled card + `ScrollArea(_build_metadata_tabs, h=420)`; citations keeps `citation-bibtex` + Clipboard; JSON accordion restyled, ids unchanged. Add `FIELD_LABELS` entries for the keys the pipeline actually writes: `hostname`, `peak_mags`, `latest_detections`, `latest_non_detections`. Delete `ALADIN_HEIGHT_PX`.
+
+**`pages/lightcurve.py`**
+- `perform_search` passes `lc_data` into `format_object_metadata`, returns the extra piece; `layout()` composes: stores · `message-banner` · `search-status` · `results-container`(results_top | empty state) · lower Grid (`metadata_card` span 7 / Stack(`object-tagging-container` div, citations) span 5) · `full_metadata`. Ids `lightcurve-store`, `results-container`, `object-tagging-container` preserved (test contract); `title_card` + big search card deleted.
+- New toggle callback: `Output lc-plot-wrap.style / lc-table-wrap.style / lc-table-wrap.children`, `Input lc-view-toggle.value + active-settings-store.data` (theme-synced swatches), `State lightcurve-store.data`. Optional clientside `Plotly.Plots.resize` on switch-back.
+- **Aladin**: delete the inline JS string (lines ~205–253); new `assets/lightcurve_aladin.js` with `window.dash_clientside.lightcurve_aladin.initialize` following the `cone_aladin.js` namespace pattern (drop the body-wide MutationObserver; poll for `#aladin-lite-div` + `window.A` like cone does). Options: survey `P/PanSTARRS/DR1/color-z-zg-g`, **fov 0.1**, `reticleColor #e34948`, marker at target. Wire via `ClientsideFunction`.
+
+### Phase 6 — Tests
+- Must pass unchanged: `test_dashboard_plots.py` empty-state contract; lightcurve empty-layout id tests; coordinates-header + `_extract_object_coordinates` tests; cone/tagged/user suites.
+- Mechanical update: `test_format_object_metadata_pieces` + `test_coordinates_header_omitted_without_coordinates` (`tarxiv/tests/test_dashboard_lightcurve.py:119,138`) unpack 4 pieces; id assertions unchanged.
+- New: `test_object_view.py` (`build_key_facts` — hostname quirk, peak-mag-under-"limit" quirk, redshift preference, detection counts, all-missing; `build_photometry_table` — sort/limits/σ/-1 exclusion); `resolve_filter_style` tests (exact hits both schemes, R→r, filter fallback, Unknown); extend plots tests (trace name "ZTF g", symbol, error_y 1.2/0, hovertemplate, limit showlegend False, tickformat "d").
+
+## Risks
+- Cone page shares ids `results-container`/`search-status`/`message-banner` and owns callbacks to them — lightcurve keeps its instances, gains no callbacks on those ids.
+- `"tarxiv_light"/"tarxiv_dark"` strings are both store values and template names — never renamed.
+- `color-scheme-toggle` + `theme-icon` ids must exist in the new header or theme callbacks break.
+- Cold-load theme flash is pre-existing behaviour, out of scope (optional later: index_string inline script).
+- Hidden-graph resize on Plot⇄Table toggle — responsive config + optional clientside resize.
+
+## Verification
+1. `uv run pytest tarxiv/tests/test_dashboard_lightcurve.py tarxiv/tests/test_dashboard_plots.py tarxiv/tests/test_dashboard_cone.py tarxiv/tests/test_dashboard_tagged.py tarxiv/tests/test_dashboard_user.py` after each phase.
+2. Run app: `uv run python bin/run_dashboard.py --debug --host 127.0.0.1` (needs the API reachable — dev docker-compose stack for a full pass).
+3. Manual: topbar on all 6 pages + active state; theme toggle (cards, banner, plot template, table swatches); mobile burger; `/lightcurve` empty state; `/lightcurve/<real id>` — page head/type chip/coord copy, 6-fact strip, plot (symbols, grouped horizontal legend, hover ±err, MJD ticks), Plot⇄Table, Aladin fov 0.1, metadata tabs, tag assign/remove, BibTeX copy, JSON accordion; cone page unaffected; global topbar search navigates from any page.

--- a/mockups/cone-1-rows.html
+++ b/mockups/cone-1-rows.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv cone mockup 1 — Compact rows</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1380px; margin: 0 auto; padding: 18px 22px 40px; }
+
+  .page-head { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
+  .page-head h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+  .page-head .spacer { flex: 1; }
+
+  .bar-wrap { margin-bottom: 10px; }
+  .sum-line { margin: 0 0 14px 2px; }
+
+  .sky-card { margin-bottom: 14px; }
+  .sky-body { height: 320px; padding: 0; border-radius: 0 0 14px 14px; overflow: hidden; }
+
+  /* the row itself: thumbnail | identity + facts | separation */
+  .rows { padding: 0; }
+  .res-row {
+    display: grid;
+    grid-template-columns: 148px minmax(0, 1fr) auto;
+    gap: 16px; align-items: center;
+    padding: 11px 16px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .res-row:last-child { border-bottom: none; }
+  .res-row:hover { background: var(--card-2); }
+  .res-row.hi { background: var(--primary-soft); }
+
+  .thumb { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+
+  .ident { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin-bottom: 5px; }
+  .facts-line { display: flex; gap: 14px; flex-wrap: wrap; align-items: baseline; }
+  .tag-line { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 6px; }
+
+  .sep-cell { text-align: right; display: flex; flex-direction: column; gap: 1px; }
+
+  .rows-foot {
+    display: flex; align-items: center; gap: 10px;
+    padding: 11px 16px; border-top: 1px solid var(--border);
+    font-size: 12.5px; color: var(--ink-3);
+  }
+  .rows-foot .spacer { flex: 1; }
+
+  @media (max-width: 900px) {
+    .res-row { grid-template-columns: 110px minmax(0, 1fr); }
+    .sep-cell { grid-column: 2; flex-direction: row; gap: 6px; align-items: baseline; }
+  }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <div class="page-head">
+    <h1>Cone search</h1>
+    <div class="spacer"></div>
+    <button class="btn btn-outline btn-sm">Export CSV</button>
+  </div>
+
+  <div class="bar-wrap" id="cone-bar"></div>
+  <p class="cone-summary sum-line" id="cone-summary"></p>
+
+  <section class="card sky-card">
+    <div class="card-head"><h2 id="sky-title"></h2><div class="spacer"></div>
+      <span class="faint small">hover a result to highlight it</span></div>
+    <div class="sky-body" id="sky"></div>
+  </section>
+
+  <section class="card rows">
+    <div class="card-head"><h2 id="res-title"></h2><div class="spacer"></div>
+      <div class="seg" id="sort-seg">
+        <button class="active" data-k="sep">Separation</button>
+        <button data-k="peak">Brightness</button>
+        <button data-k="date">Recency</button>
+      </div>
+    </div>
+    <div id="res-list"></div>
+    <div class="rows-foot">
+      <span>Showing <b>1&ndash;20</b> of 24</span>
+      <div class="spacer"></div>
+      <button class="btn btn-ghost btn-sm">Previous</button>
+      <button class="btn btn-outline btn-sm">Next</button>
+    </div>
+  </section>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("cone");
+  document.getElementById("sky-title").innerHTML = ICONS.globe + " Sky view";
+  document.getElementById("res-title").innerHTML = ICONS.curve + " Results";
+
+  mountConeSearchBar(document.getElementById("cone-bar"));
+  document.getElementById("cone-summary").innerHTML = coneSummaryHTML(CONE_RESULTS);
+  mountConeAladin(document.getElementById("sky"));
+
+  const rowHTML = (o, i) => `
+    <div class="res-row" data-i="${i}">
+      <div class="thumb">
+        ${sparklineSVG(o.phot)}
+        <div class="band-chips">${bandChipsHTML(o.phot)}</div>
+      </div>
+      <div>
+        <div class="ident">${coneNameHTML(o)} ${fmtType(o.object_type)}</div>
+        <div class="facts-line">
+          <span class="kv"><span class="k">z</span><span class="v">${fmtZ(o.redshift)}</span></span>
+          <span class="kv"><span class="k">peak</span><span class="v">${fmtMag(o.peak_mag)} ${o.peak_filter}</span></span>
+          <span class="kv"><span class="k">dets</span><span class="v">${o.n_detections}</span></span>
+          <span class="kv"><span class="k">host</span><span class="v">${o.host || EM_DASH}</span></span>
+          <span class="kv"><span class="k">found</span><span class="v">${o.discovery_date}</span></span>
+          <span class="src-pills">${coneSourcesHTML(o.sources)}</span>
+        </div>
+        ${o.tags.length ? `<div class="tag-line">${coneTagsHTML(o.tags)}</div>` : ""}
+      </div>
+      <div class="sep-cell">
+        <span class="sep-val">${fmtSep(o.sep_arcsec)}</span>
+        <span class="sep-lab">separation</span>
+      </div>
+    </div>`;
+
+  const list = document.getElementById("res-list");
+  const draw = () => { list.innerHTML = CONE_RESULTS.slice(0, 20).map(rowHTML).join(""); };
+  draw();
+  onThemeChange(draw);   /* sparklines are theme-coloured, so redraw them */
+
+  /* row hover <-> sky marker, mirroring the behaviour the real page already has */
+  list.addEventListener("mouseover", (e) => {
+    const row = e.target.closest(".res-row");
+    if (row) row.classList.add("hi");
+  });
+  list.addEventListener("mouseout", (e) => {
+    const row = e.target.closest(".res-row");
+    if (row) row.classList.remove("hi");
+  });
+
+  document.querySelectorAll("#sort-seg button").forEach((b) => {
+    b.onclick = () => document.querySelectorAll("#sort-seg button")
+      .forEach((x) => x.classList.toggle("active", x === b));
+  });
+</script>
+</body>
+</html>

--- a/mockups/cone-2-grid.html
+++ b/mockups/cone-2-grid.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv cone mockup 2 — Card grid</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1380px; margin: 0 auto; padding: 18px 22px 40px; }
+
+  .page-head { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
+  .page-head h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+  .page-head .spacer { flex: 1; }
+
+  .bar-wrap { margin-bottom: 10px; }
+  .sum-line { margin: 0 0 14px 2px; }
+
+  .sky-card { margin-bottom: 16px; }
+  .sky-body { height: 300px; padding: 0; border-radius: 0 0 14px 14px; overflow: hidden; }
+
+  .sec-label {
+    display: flex; align-items: center; gap: 10px;
+    font-size: 11px; font-weight: 700; letter-spacing: 0.09em;
+    text-transform: uppercase; color: var(--ink-3);
+    margin: 0 2px 12px;
+  }
+  .sec-label .spacer { flex: 1; }
+
+  /* the grid: browse-oriented, one card per object */
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(288px, 1fr)); gap: 14px; }
+
+  .obj-card {
+    display: flex; flex-direction: column;
+    padding: 0; overflow: hidden;
+    transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+    cursor: pointer;
+  }
+  .obj-card:hover {
+    border-color: var(--primary-ink); transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  /* sparkline sits on the inset surface so it reads as a preview, not chrome */
+  .card-spark {
+    background: var(--card-2); border-bottom: 1px solid var(--border);
+    padding: 10px 12px 8px; display: flex; flex-direction: column; gap: 6px;
+  }
+  .card-spark svg { width: 100%; height: 64px; }
+  .card-spark .row { display: flex; align-items: center; }
+  .card-spark .row .spacer { flex: 1; }
+
+  .card-main { padding: 12px 14px 14px; display: flex; flex-direction: column; gap: 10px; }
+  .card-ident { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+  .mini-stats {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 10px 12px;
+    padding-top: 2px;
+  }
+
+  .card-foot {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    padding-top: 10px; border-top: 1px solid var(--border);
+  }
+  .card-foot .spacer { flex: 1; }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <div class="page-head">
+    <h1>Cone search</h1>
+    <div class="spacer"></div>
+    <button class="btn btn-outline btn-sm">Export CSV</button>
+  </div>
+
+  <div class="bar-wrap" id="cone-bar"></div>
+  <p class="cone-summary sum-line" id="cone-summary"></p>
+
+  <section class="card sky-card">
+    <div class="card-head"><h2 id="sky-title"></h2></div>
+    <div class="sky-body" id="sky"></div>
+  </section>
+
+  <div class="sec-label">
+    <span>Objects found</span>
+    <div class="spacer"></div>
+    <div class="seg" id="sort-seg">
+      <button class="active" data-k="sep">Separation</button>
+      <button data-k="peak">Brightness</button>
+      <button data-k="date">Recency</button>
+    </div>
+  </div>
+
+  <div class="grid" id="res-grid"></div>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("cone");
+  document.getElementById("sky-title").innerHTML = ICONS.globe + " Sky view";
+
+  mountConeSearchBar(document.getElementById("cone-bar"));
+  document.getElementById("cone-summary").innerHTML = coneSummaryHTML(CONE_RESULTS);
+  mountConeAladin(document.getElementById("sky"));
+
+  const cardHTML = (o) => `
+    <article class="card obj-card">
+      <div class="card-spark">
+        ${sparklineSVG(o.phot, currentTheme(), { w: 262, h: 64 })}
+        <div class="row">
+          <div class="band-chips">${bandChipsHTML(o.phot)}</div>
+          <div class="spacer"></div>
+          <span class="kv"><span class="k">peak</span><span class="v">${fmtMag(o.peak_mag)} ${o.peak_filter}</span></span>
+        </div>
+      </div>
+      <div class="card-main">
+        <div class="card-ident">${coneNameHTML(o)} ${fmtType(o.object_type)}</div>
+        <div class="mini-stats">
+          <div class="stat"><div class="k">Separation</div><div class="v">${fmtSep(o.sep_arcsec)}</div></div>
+          <div class="stat"><div class="k">Redshift</div><div class="v">${fmtZ(o.redshift)}</div></div>
+          <div class="stat"><div class="k">Detections</div><div class="v">${o.n_detections}</div></div>
+          <div class="stat"><div class="k">Discovered</div><div class="v">${o.discovery_date}</div></div>
+        </div>
+        <div class="kv"><span class="k">host</span><span class="v">${o.host || EM_DASH}</span></div>
+        ${o.tags.length ? `<div style="display:flex;gap:5px;flex-wrap:wrap">${coneTagsHTML(o.tags)}</div>` : ""}
+        <div class="card-foot">
+          <span class="src-pills">${coneSourcesHTML(o.sources)}</span>
+        </div>
+      </div>
+    </article>`;
+
+  const grid = document.getElementById("res-grid");
+  const draw = () => { grid.innerHTML = CONE_RESULTS.map(cardHTML).join(""); };
+  draw();
+  onThemeChange(draw);   /* sparklines are theme-coloured, so redraw them */
+
+  document.querySelectorAll("#sort-seg button").forEach((b) => {
+    b.onclick = () => document.querySelectorAll("#sort-seg button")
+      .forEach((x) => x.classList.toggle("active", x === b));
+  });
+</script>
+</body>
+</html>

--- a/mockups/cone-3-split.html
+++ b/mockups/cone-3-split.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv cone mockup 3 — Split workspace</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1440px; margin: 0 auto; padding: 18px 22px 40px; }
+
+  .page-head { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
+  .page-head h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+  .page-head .spacer { flex: 1; }
+
+  .bar-wrap { margin-bottom: 10px; }
+  .sum-line { margin: 0 0 14px 2px; }
+
+  /* sky sticks while the result list scrolls past it — the point of this layout */
+  .split { display: grid; grid-template-columns: minmax(0, 5fr) minmax(0, 7fr); gap: 14px; align-items: start; }
+
+  .sky-col { position: sticky; top: 66px; display: flex; flex-direction: column; gap: 14px; }
+  .sky-body { height: calc(100vh - 320px); min-height: 340px; padding: 0; border-radius: 0 0 14px 14px; overflow: hidden; }
+
+  .legend-card { padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
+  .legend-row { display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--ink-2); }
+  .legend-row .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--primary); flex-shrink: 0; }
+  .legend-row .ring { width: 9px; height: 9px; border-radius: 50%; border: 1.5px solid var(--primary); flex-shrink: 0; }
+
+  .list-card { padding: 0; }
+
+  .res-row {
+    display: grid; grid-template-columns: 120px minmax(0, 1fr) auto;
+    gap: 14px; align-items: center;
+    padding: 10px 14px; border-bottom: 1px solid var(--border);
+    cursor: pointer; transition: background 0.12s;
+  }
+  .res-row:hover { background: var(--card-2); }
+  .res-row.open { background: var(--primary-soft); }
+
+  .thumb { display: flex; flex-direction: column; gap: 4px; }
+  .ident { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 4px; }
+  .facts-line { display: flex; gap: 12px; flex-wrap: wrap; align-items: baseline; }
+  .sep-cell { text-align: right; display: flex; flex-direction: column; gap: 1px; }
+
+  /* the expanded detail — a real Plotly lightcurve, no navigation needed */
+  .detail { border-bottom: 1px solid var(--border); background: var(--card-2); padding: 14px 16px 16px; }
+  .detail-grid { display: grid; grid-template-columns: minmax(0, 3fr) minmax(0, 2fr); gap: 16px; }
+  .detail-plot { height: 260px; background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 6px; }
+  .detail-side { display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+  .detail-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 2px; }
+
+  @media (max-width: 1080px) {
+    .split { grid-template-columns: 1fr; }
+    .sky-col { position: static; }
+    .sky-body { height: 300px; }
+    .detail-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <div class="page-head">
+    <h1>Cone search</h1>
+    <div class="spacer"></div>
+    <button class="btn btn-outline btn-sm">Export CSV</button>
+  </div>
+
+  <div class="bar-wrap" id="cone-bar"></div>
+  <p class="cone-summary sum-line" id="cone-summary"></p>
+
+  <div class="split">
+    <div class="sky-col">
+      <section class="card">
+        <div class="card-head"><h2 id="sky-title"></h2></div>
+        <div class="sky-body" id="sky"></div>
+      </section>
+      <section class="card legend-card">
+        <div class="legend-row"><span class="ring"></span> Search radius &mdash; <span class="mono">600&Prime;</span></div>
+        <div class="legend-row"><span class="dot"></span> Result marker &mdash; hover a row to highlight</div>
+        <div class="legend-row faint">Click any row to open its lightcurve without leaving the page.</div>
+      </section>
+    </div>
+
+    <section class="card list-card">
+      <div class="card-head"><h2 id="res-title"></h2><div class="spacer"></div>
+        <span class="faint small">click to expand</span></div>
+      <div id="res-list"></div>
+    </section>
+  </div>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("cone");
+  document.getElementById("sky-title").innerHTML = ICONS.globe + " Sky view";
+  document.getElementById("res-title").innerHTML = ICONS.curve + " Results";
+
+  mountConeSearchBar(document.getElementById("cone-bar"));
+  document.getElementById("cone-summary").innerHTML = coneSummaryHTML(CONE_RESULTS);
+  mountConeAladin(document.getElementById("sky"));
+
+  const rowHTML = (o, i) => `
+    <div class="res-row" data-i="${i}">
+      <div class="thumb">
+        ${sparklineSVG(o.phot, currentTheme(), { w: 120, h: 38 })}
+        <div class="band-chips">${bandChipsHTML(o.phot)}</div>
+      </div>
+      <div>
+        <div class="ident">${coneNameHTML(o)} ${fmtType(o.object_type)}</div>
+        <div class="facts-line">
+          <span class="kv"><span class="k">z</span><span class="v">${fmtZ(o.redshift)}</span></span>
+          <span class="kv"><span class="k">peak</span><span class="v">${fmtMag(o.peak_mag)} ${o.peak_filter}</span></span>
+          <span class="kv"><span class="k">dets</span><span class="v">${o.n_detections}</span></span>
+          <span class="src-pills">${coneSourcesHTML(o.sources)}</span>
+        </div>
+      </div>
+      <div class="sep-cell">
+        <span class="sep-val">${fmtSep(o.sep_arcsec)}</span>
+        <span class="sep-lab">sep</span>
+      </div>
+    </div>
+    <div class="detail" id="d-${i}" hidden>
+      <div class="detail-grid">
+        <div class="detail-plot"><div class="plot-host" id="p-${i}"></div></div>
+        <div class="detail-side">
+          <div class="facts">
+            <div class="fact"><span class="k">Coordinates</span><span class="v mono">${o.ra_hms} ${o.dec_dms}</span></div>
+            <div class="fact"><span class="k">Decimal</span><span class="v mono">${o.ra.toFixed(6)} ${o.dec >= 0 ? "+" : ""}${o.dec.toFixed(6)}</span></div>
+            <div class="fact"><span class="k">TarXiv ID</span><span class="v mono">${o.tarxiv_id}</span></div>
+            <div class="fact"><span class="k">Host</span><span class="v">${o.host || EM_DASH}</span></div>
+            <div class="fact"><span class="k">Host separation</span><span class="v">${o.host_sep_kpc ? o.host_sep_kpc + " kpc" : EM_DASH}</span></div>
+            <div class="fact"><span class="k">Discovered</span><span class="v">${o.discovery_date} &middot; ${o.reporting_group}</span></div>
+          </div>
+          ${o.tags.length ? `<div style="display:flex;gap:5px;flex-wrap:wrap">${coneTagsHTML(o.tags)}</div>` : ""}
+          <div class="detail-actions">
+            <a class="btn btn-primary btn-sm" href="mockup-2-balanced.html">Open object page</a>
+            <button class="btn btn-outline btn-sm">Add tag</button>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+  const list = document.getElementById("res-list");
+  const open = new Set();
+
+  const draw = () => {
+    list.innerHTML = CONE_RESULTS.map(rowHTML).join("");
+    /* re-open whatever was open before the redraw, and re-plot it */
+    open.forEach((i) => {
+      document.getElementById("d-" + i).hidden = false;
+      list.querySelector(`.res-row[data-i="${i}"]`).classList.add("open");
+      mountLightcurve(document.getElementById("p-" + i), { compact: true });
+    });
+  };
+  draw();
+  onThemeChange(draw);   /* sparklines are theme-coloured, so redraw them */
+
+  list.addEventListener("click", (e) => {
+    const row = e.target.closest(".res-row");
+    if (!row || e.target.closest("a")) return;
+    const i = row.dataset.i;
+    const panel = document.getElementById("d-" + i);
+    const nowOpen = panel.hidden;
+    panel.hidden = !nowOpen;
+    row.classList.toggle("open", nowOpen);
+    if (nowOpen) {
+      open.add(i);
+      /* the mockup plots the same sample lightcurve for every object */
+      mountLightcurve(document.getElementById("p-" + i), { compact: true });
+    } else {
+      open.delete(i);
+    }
+  });
+</script>
+</body>
+</html>

--- a/mockups/cone-4-table.html
+++ b/mockups/cone-4-table.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv cone mockup 4 — Data table</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1440px; margin: 0 auto; padding: 18px 22px 40px; }
+
+  .page-head { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
+  .page-head h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+  .page-head .spacer { flex: 1; }
+
+  .bar-wrap { margin-bottom: 10px; }
+  .sum-line { margin: 0 0 14px 2px; }
+
+  /* sky collapses away — this layout is for triaging a long list, not looking */
+  .sky-fold { margin-bottom: 14px; }
+  .sky-body { height: 320px; padding: 0; margin-top: 4px; border-radius: 10px; overflow: hidden;
+              border: 1px solid var(--border); }
+
+  .table-card { padding: 0; overflow: hidden; }
+  .table-wrap { overflow-x: auto; }
+
+  .cone-table th { cursor: pointer; user-select: none; white-space: nowrap; }
+  .cone-table th:hover { color: var(--ink-2); }
+  .cone-table th svg { opacity: 0.45; vertical-align: -1px; margin-left: 2px; }
+  .cone-table th.sorted svg { opacity: 1; }
+  .cone-table th.sorted { color: var(--primary-ink); }
+
+  .cone-table tbody tr { cursor: pointer; }
+  .cone-table tbody tr:hover td { background: var(--card-2); }
+  .cone-table tr.open td { background: var(--primary-soft); }
+  .cone-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .cone-table td.name { font-weight: 700; white-space: nowrap; }
+  .cone-table td.spark-cell { padding: 2px 10px; width: 108px; }
+  .cone-table td.spark-cell svg { vertical-align: middle; }
+
+  .detail-td { padding: 0 !important; background: var(--card-2); }
+  .detail-inner { padding: 14px 16px; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto; gap: 18px; }
+
+  .table-foot {
+    display: flex; align-items: center; gap: 10px;
+    padding: 11px 16px; border-top: 1px solid var(--border);
+    font-size: 12.5px; color: var(--ink-3);
+  }
+  .table-foot .spacer { flex: 1; }
+
+  @media (max-width: 900px) { .detail-inner { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <div class="page-head">
+    <h1>Cone search</h1>
+    <div class="spacer"></div>
+    <button class="btn btn-outline btn-sm">Export CSV</button>
+  </div>
+
+  <div class="bar-wrap" id="cone-bar"></div>
+  <p class="cone-summary sum-line" id="cone-summary"></p>
+
+  <details class="accordion sky-fold">
+    <summary><span id="fold-icon"></span> Sky view <span class="faint" style="font-weight:400">&mdash; 24 markers</span></summary>
+    <div class="accordion-body"><div class="sky-body" id="sky"></div></div>
+  </details>
+
+  <section class="card table-card">
+    <div class="card-head"><h2 id="res-title"></h2><div class="spacer"></div>
+      <span class="faint small">click a row to expand</span></div>
+    <div class="table-wrap">
+      <table class="data-table cone-table" id="res-table">
+        <thead><tr id="res-head"></tr></thead>
+        <tbody id="res-body"></tbody>
+      </table>
+    </div>
+    <div class="table-foot">
+      <span>Showing <b>24</b> of 24 &middot; 50 per page</span>
+      <div class="spacer"></div>
+      <button class="btn btn-ghost btn-sm">Previous</button>
+      <button class="btn btn-outline btn-sm">Next</button>
+    </div>
+  </section>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("cone");
+  document.getElementById("res-title").innerHTML = ICONS.table + " Results";
+  document.getElementById("fold-icon").innerHTML = ICONS.chev;
+
+  mountConeSearchBar(document.getElementById("cone-bar"));
+  document.getElementById("cone-summary").innerHTML = coneSummaryHTML(CONE_RESULTS);
+  mountConeAladin(document.getElementById("sky"));
+
+  const COLS = [
+    { k: "obj_name",    label: "Name",   cls: "name" },
+    { k: "object_type", label: "Type",   cls: "" },
+    { k: "sep_arcsec",  label: "Sep",    cls: "num" },
+    { k: "ra",          label: "RA",     cls: "num mono" },
+    { k: "dec",         label: "Dec",    cls: "num mono" },
+    { k: "redshift",    label: "z",      cls: "num" },
+    { k: "peak_mag",    label: "Peak",   cls: "num" },
+    { k: "n_detections", label: "Dets",  cls: "num" },
+    { k: "discovery_date", label: "Found", cls: "" },
+    { k: "sources",     label: "Sources", cls: "" },
+    { k: "phot",        label: "Lightcurve", cls: "spark-cell" },
+  ];
+
+  let sortKey = "sep_arcsec", sortAsc = true;
+
+  const cellHTML = (o, c) => {
+    switch (c.k) {
+      case "obj_name":  return coneNameHTML(o);
+      case "object_type": return fmtType(o.object_type);
+      case "sep_arcsec": return fmtSep(o.sep_arcsec);
+      case "ra":        return o.ra.toFixed(5);
+      case "dec":       return (o.dec >= 0 ? "+" : "") + o.dec.toFixed(5);
+      case "redshift":  return fmtZ(o.redshift);
+      case "peak_mag":  return `${fmtMag(o.peak_mag)} <span class="faint">${o.peak_filter}</span>`;
+      case "n_detections": return o.n_detections;
+      case "discovery_date": return o.discovery_date;
+      case "sources":   return `<span class="src-pills">${coneSourcesHTML(o.sources)}</span>`;
+      case "phot":      return sparklineSVG(o.phot, currentTheme(), { w: 96, h: 30 });
+      default:          return "";
+    }
+  };
+
+  const detailHTML = (o) => `
+    <tr class="detail-row" hidden><td class="detail-td" colspan="${COLS.length}">
+      <div class="detail-inner">
+        <div class="facts">
+          <div class="fact"><span class="k">Sexagesimal</span><span class="v mono">${o.ra_hms} ${o.dec_dms}</span></div>
+          <div class="fact"><span class="k">TarXiv ID</span><span class="v mono">${o.tarxiv_id}</span></div>
+          <div class="fact"><span class="k">ZTF alias</span><span class="v mono">${o.ztf_id || EM_DASH}</span></div>
+        </div>
+        <div class="facts">
+          <div class="fact"><span class="k">Host</span><span class="v">${o.host || EM_DASH}</span></div>
+          <div class="fact"><span class="k">Host separation</span><span class="v">${o.host_sep_kpc ? o.host_sep_kpc + " kpc" : EM_DASH}</span></div>
+          <div class="fact"><span class="k">Reporting group</span><span class="v">${o.reporting_group}</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:9px;align-items:flex-start">
+          <div class="band-chips">${bandChipsHTML(o.phot)}</div>
+          ${o.tags.length ? `<div style="display:flex;gap:5px;flex-wrap:wrap">${coneTagsHTML(o.tags)}</div>` : ""}
+          <a class="btn btn-primary btn-sm" href="mockup-2-balanced.html">Open object page</a>
+        </div>
+      </div>
+    </td></tr>`;
+
+  const sorted = () => {
+    const v = (o) => {
+      const x = o[sortKey];
+      if (x == null) return sortAsc ? Infinity : -Infinity;   /* nulls always last */
+      return x;
+    };
+    return [...CONE_RESULTS].sort((a, b) => {
+      const av = v(a), bv = v(b);
+      if (av === bv) return 0;
+      return (av < bv ? -1 : 1) * (sortAsc ? 1 : -1);
+    });
+  };
+
+  const draw = () => {
+    document.getElementById("res-head").innerHTML = COLS.map((c) =>
+      `<th data-k="${c.k}" class="${sortKey === c.k ? "sorted" : ""}">${c.label}${
+        c.k === "phot" ? "" : ICONS.sort}</th>`).join("");
+
+    document.getElementById("res-body").innerHTML = sorted().map((o) =>
+      `<tr class="obj-row">${COLS.map((c) =>
+        `<td class="${c.cls}">${cellHTML(o, c)}</td>`).join("")}</tr>` + detailHTML(o)).join("");
+  };
+  draw();
+  onThemeChange(draw);   /* sparklines are theme-coloured, so redraw them */
+
+  document.getElementById("res-head").addEventListener("click", (e) => {
+    const th = e.target.closest("th");
+    if (!th || th.dataset.k === "phot") return;
+    if (sortKey === th.dataset.k) { sortAsc = !sortAsc; } else { sortKey = th.dataset.k; sortAsc = true; }
+    draw();
+  });
+
+  document.getElementById("res-body").addEventListener("click", (e) => {
+    const row = e.target.closest(".obj-row");
+    if (!row || e.target.closest("a")) return;
+    const detail = row.nextElementSibling;
+    detail.hidden = !detail.hidden;
+    row.classList.toggle("open", !detail.hidden);
+  });
+</script>
+</body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -33,6 +33,13 @@
   .option .trade { margin-top: 10px; font-size: 12px; color: var(--ink-3); }
   .option .trade b { color: var(--ink-2); }
 
+  .option.chosen { border-color: var(--primary-ink); }
+  .pick {
+    display: inline-block; margin-left: 6px; padding: 1px 7px; border-radius: 999px;
+    background: var(--primary-soft-2); color: var(--primary-ink);
+    font-size: 10px; letter-spacing: 0.06em;
+  }
+
   .swatches { display: flex; gap: 10px; flex-wrap: wrap; }
   .swatch-tile { width: 108px; }
   .swatch-tile .sq {
@@ -53,19 +60,18 @@
 
 <header class="topbar">
   <a class="wordmark" href="index.html">tar<span class="x">X</span>iv</a>
-  <span class="faint small">redesign mockups · July 2026</span>
+  <span class="faint small">redesign mockups · August 2026</span>
   <div class="spacer"></div>
   <button class="icon-btn" onclick="toggleTheme()" title="Toggle theme" id="theme-btn"></button>
 </header>
 
 <div class="container">
-  <h1>Lightcurve page redesign</h1>
-  <p class="lede">Four layout options for the TarXiv lightcurve page, sharing one visual
-  language: refined arXiv-red palette, neutral surfaces, Inter + JetBrains Mono, live
-  Plotly + Aladin widgets on SN 2023ixf. Toggle light/dark in any page — the choice
-  persists across all of them.</p>
+  <h1>TarXiv redesign mockups</h1>
+  <p class="lede">Layout options for the pages being reworked, sharing one visual language:
+  refined arXiv-red palette, neutral surfaces, Inter + JetBrains Mono, live Plotly + Aladin
+  widgets. Toggle light/dark in any page — the choice persists across all of them.</p>
 
-  <h2>Options</h2>
+  <h2>Lightcurve page</h2>
   <div class="options">
     <a class="card option" href="mockup-1-dense.html">
       <div class="num">Option 1 · Dense</div>
@@ -76,8 +82,8 @@
          small laptops; low-frequency content is a click away rather than visible.</div>
     </a>
 
-    <a class="card option" href="mockup-2-balanced.html">
-      <div class="num">Option 2 · Middle ground</div>
+    <a class="card option chosen" href="mockup-2-balanced.html">
+      <div class="num">Option 2 · Middle ground <span class="pick">chosen</span></div>
       <h3>Balanced</h3>
       <p>A summary strip of key facts + lightcurve + sky view all above the fold at 1440×900;
          full metadata, tags and citations one short scroll below.</p>
@@ -104,6 +110,52 @@
     </a>
   </div>
 
+  <h2>Cone search page</h2>
+  <p class="lede" style="margin:-4px 0 14px;font-size:13px">All four share the same
+  <b>compressed search bar</b> — one row of fields with a <span class="mono">deg ↔ hms:dms</span>
+  toggle that converts in place, replacing today's three stacked OR'd input blocks (~380px of
+  form before a single result). They differ only in how the objects under the sky map are
+  presented.</p>
+  <div class="options">
+    <a class="card option" href="cone-1-rows.html">
+      <div class="num">Option 1 · Compact rows</div>
+      <h3>Dense list</h3>
+      <p>Sky map full width, then one row per object: lightcurve thumbnail, name and type,
+         redshift/peak/host inline, tags, separation right-aligned. Hovering a row highlights
+         its marker.</p>
+      <div class="trade"><b>Trade-off:</b> the closest step from what exists today, so it is the
+         least exciting; facts wrap awkwardly below ~900px.</div>
+    </a>
+
+    <a class="card option" href="cone-2-grid.html">
+      <div class="num">Option 2 · Card grid</div>
+      <h3>Browsable tiles</h3>
+      <p>A responsive grid of cards, each led by a full-width lightcurve thumbnail on an inset
+         surface, then a 2×2 stat block, host, tags and source pills.</p>
+      <div class="trade"><b>Trade-off:</b> roughly 3× the vertical space per object — you see six
+         at a time rather than twenty, so it suits small result sets.</div>
+    </a>
+
+    <a class="card option" href="cone-3-split.html">
+      <div class="num">Option 3 · Split workspace</div>
+      <h3>Sky beside results</h3>
+      <p>Sticky sky map on the left while results scroll on the right. Clicking a row expands a
+         real Plotly lightcurve and full coordinates inline — triage without ever leaving the
+         search.</p>
+      <div class="trade"><b>Trade-off:</b> halves the width available to each result row; collapses
+         to stacked panels below 1080px, losing the side-by-side benefit.</div>
+    </a>
+
+    <a class="card option" href="cone-4-table.html">
+      <div class="num">Option 4 · Data table</div>
+      <h3>Triage grid</h3>
+      <p>Sky map folds away; results become a sortable table with a sparkline column. Click any
+         row to expand its full facts. Built for scanning a large cone quickly.</p>
+      <div class="trade"><b>Trade-off:</b> the least visual of the four, and wide enough to need
+         horizontal scroll on a laptop; tags and host hide until a row is expanded.</div>
+    </a>
+  </div>
+
   <h2>Shared palette</h2>
   <div class="swatches" id="brand-swatches"></div>
 
@@ -115,8 +167,18 @@
   <div class="swatches" id="filter-swatches"></div>
 
   <div class="note"><b>Viewing notes:</b> widgets load Plotly and Aladin Lite from CDN, so these
-  pages need network access. Option 1 targets ≥1280×800 for its no-scroll guarantee. Nothing in
-  the app codebase is modified — these are standalone HTML files in <span class="mono">mockups/</span>.</div>
+  pages need network access. Lightcurve option 1 targets ≥1280×800 for its no-scroll guarantee.
+  Nothing in the app codebase is modified — these are standalone HTML files in
+  <span class="mono">mockups/</span>.</div>
+
+  <div class="note"><b>Cone search needs backend work, not just CSS:</b> the
+  <span class="mono">/cone_search</span> endpoint returns exactly four fields per object today —
+  <span class="mono">obj_name</span>, <span class="mono">ra</span>, <span class="mono">dec</span>,
+  <span class="mono">distance_deg</span>. Every richer thing shown here — type, redshift, host,
+  peak magnitude, detection counts, tags and the lightcurve thumbnails — needs the results to be
+  enriched from object metadata first. <span class="mono">format_cone_search_results()</span>
+  already takes an unused <span class="mono">txv_db</span> argument, which is the intended hook.
+  Object names, coordinates and photometry on these pages are generated placeholders.</div>
 </div>
 
 <script src="shared.js"></script>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv redesign mockups</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<style>
+  .container { max-width: 980px; margin: 0 auto; padding: 56px 28px 80px; }
+  h1 { font-size: 34px; font-weight: 800; letter-spacing: -0.03em; }
+  .lede { color: var(--ink-2); font-size: 15px; margin-top: 10px; max-width: 640px; }
+
+  h2 { font-size: 13px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+       color: var(--ink-3); margin: 44px 0 14px; }
+
+  .options { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .option {
+    display: block; padding: 20px; color: inherit;
+    transition: border-color 0.15s, transform 0.15s;
+  }
+  .option:hover { text-decoration: none; border-color: var(--primary-ink); transform: translateY(-1px); }
+  .option .num {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--primary-ink); margin-bottom: 6px;
+  }
+  .option h3 { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+  .option p { color: var(--ink-2); font-size: 13px; margin-top: 6px; }
+  .option .trade { margin-top: 10px; font-size: 12px; color: var(--ink-3); }
+  .option .trade b { color: var(--ink-2); }
+
+  .swatches { display: flex; gap: 10px; flex-wrap: wrap; }
+  .swatch-tile { width: 108px; }
+  .swatch-tile .sq {
+    height: 52px; border-radius: 10px; border: 1px solid var(--border);
+  }
+  .swatch-tile .name { font-size: 11px; font-weight: 600; margin-top: 6px; }
+  .swatch-tile .hex { font-size: 10.5px; color: var(--ink-3); }
+
+  .note {
+    margin-top: 40px; padding: 14px 18px; font-size: 13px; color: var(--ink-2);
+    background: var(--primary-soft); border: 1px solid transparent; border-radius: 12px;
+  }
+  .note b { color: var(--primary-ink); }
+  @media (max-width: 760px) { .options { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <a class="wordmark" href="index.html">tar<span class="x">X</span>iv</a>
+  <span class="faint small">redesign mockups · July 2026</span>
+  <div class="spacer"></div>
+  <button class="icon-btn" onclick="toggleTheme()" title="Toggle theme" id="theme-btn"></button>
+</header>
+
+<div class="container">
+  <h1>Lightcurve page redesign</h1>
+  <p class="lede">Four layout options for the TarXiv lightcurve page, sharing one visual
+  language: refined arXiv-red palette, neutral surfaces, Inter + JetBrains Mono, live
+  Plotly + Aladin widgets on SN 2023ixf. Toggle light/dark in any page — the choice
+  persists across all of them.</p>
+
+  <h2>Options</h2>
+  <div class="options">
+    <a class="card option" href="mockup-1-dense.html">
+      <div class="num">Option 1 · Dense</div>
+      <h3>Mission control</h3>
+      <p>Everything on one screen, zero page scroll: lightcurve, sky view and metadata in a
+         fixed 100vh grid. Tags, citations and JSON move to slide-in drawers.</p>
+      <div class="trade"><b>Trade-off:</b> metadata pane scrolls internally and gets tight on
+         small laptops; low-frequency content is a click away rather than visible.</div>
+    </a>
+
+    <a class="card option" href="mockup-2-balanced.html">
+      <div class="num">Option 2 · Middle ground</div>
+      <h3>Balanced</h3>
+      <p>A summary strip of key facts + lightcurve + sky view all above the fold at 1440×900;
+         full metadata, tags and citations one short scroll below.</p>
+      <div class="trade"><b>Trade-off:</b> the summary strip must choose the "key" fields —
+         the full per-source tables aren't visible without scrolling.</div>
+    </a>
+
+    <a class="card option" href="mockup-3-spacious.html">
+      <div class="num">Option 3 · Spacious</div>
+      <h3>Editorial</h3>
+      <p>Generous whitespace and narrative sections: hero identity block, full-width
+         lightcurve, sky context with host-association highlights, then provenance.</p>
+      <div class="trade"><b>Trade-off:</b> deliberately fails the no-scroll request — included
+         as the other extreme to calibrate against.</div>
+    </a>
+
+    <a class="card option" href="mockup-4-workspace.html">
+      <div class="num">Option 4 · Wildcard</div>
+      <h3>Workspace</h3>
+      <p>A persistent object sidebar (identity, key facts, tags, source links) beside tabbed
+         panels: overview split view, photometry table, metadata, citations, JSON.</p>
+      <div class="trade"><b>Trade-off:</b> a bigger departure from the current page model;
+         tabs hide the panels you're not on.</div>
+    </a>
+  </div>
+
+  <h2>Shared palette</h2>
+  <div class="swatches" id="brand-swatches"></div>
+
+  <h2>Filter colours (validated)</h2>
+  <p class="lede" style="margin:0 0 14px;font-size:13px">Checked with a colour-vision-deficiency
+  palette validator (all-pairs, both themes) against the card surfaces — replacing the current CSS
+  named colours. Marker shapes differ per filter as secondary encoding, and every mockup ships a
+  photometry table view.</p>
+  <div class="swatches" id="filter-swatches"></div>
+
+  <div class="note"><b>Viewing notes:</b> widgets load Plotly and Aladin Lite from CDN, so these
+  pages need network access. Option 1 targets ≥1280×800 for its no-scroll guarantee. Nothing in
+  the app codebase is modified — these are standalone HTML files in <span class="mono">mockups/</span>.</div>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("theme-btn").innerHTML = ICONS.sun + ICONS.moon;
+
+  const brand = [
+    ["Primary", "#b31b1b"], ["Primary hover", "#971616"], ["Red on dark", "#e06058"],
+    ["Bg light", "#f7f7f8"], ["Card light", "#ffffff"],
+    ["Bg dark", "#121617"], ["Card dark", "#1c2224"],
+  ];
+  document.getElementById("brand-swatches").innerHTML = brand.map(([n, h]) =>
+    `<div class="swatch-tile"><div class="sq" style="background:${h}"></div>
+     <div class="name">${n}</div><div class="hex mono">${h}</div></div>`).join("");
+
+  const renderFilters = () => {
+    const t = currentTheme();
+    document.getElementById("filter-swatches").innerHTML =
+      Object.entries(FILTER_STYLE).map(([n, s]) =>
+        `<div class="swatch-tile"><div class="sq" style="background:${s[t]}"></div>
+         <div class="name">${n}</div><div class="hex mono">${s[t]} · ${s.symbol}</div></div>`).join("");
+  };
+  renderFilters();
+  onThemeChange(renderFilters);
+</script>
+</body>
+</html>

--- a/mockups/mockup-1-dense.html
+++ b/mockups/mockup-1-dense.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv mockup 1 — Mission control (dense)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  html, body { overflow: hidden; }   /* the whole point: no page scroll */
+
+  .shell { height: 100vh; display: flex; flex-direction: column; }
+
+  /* slim object identity strip */
+  .objbar {
+    display: flex; align-items: center; gap: 14px;
+    padding: 0 20px; height: 46px; flex-shrink: 0;
+    border-bottom: 1px solid var(--border);
+    background: var(--card);
+    overflow-x: auto;
+  }
+  .objbar h1 { font-size: 16px; font-weight: 700; letter-spacing: -0.01em; white-space: nowrap; }
+  .objbar .sep { width: 1px; height: 20px; background: var(--border-strong); flex-shrink: 0; }
+
+  .main {
+    flex: 1; min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(340px, 34vw, 480px);
+    grid-template-rows: minmax(0, 11fr) minmax(0, 9fr);
+    gap: 10px; padding: 10px 12px;
+  }
+  .main .card { display: flex; flex-direction: column; min-height: 0; }
+  .main .card .card-body { flex: 1; min-height: 0; padding: 8px; }
+
+  #lc-card { grid-row: 1 / 3; }
+  #lc-table-wrap { display: none; overflow: auto; height: 100%; padding: 0 8px; }
+  #lc-card.show-table #lc-table-wrap { display: block; }
+  #lc-card.show-table #lc-plot { display: none; }
+
+  .statusbar {
+    display: flex; align-items: center; gap: 8px;
+    height: 38px; flex-shrink: 0; padding: 0 12px;
+    border-top: 1px solid var(--border); background: var(--card);
+    font-size: 12px; color: var(--ink-2);
+  }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <header class="topbar" id="topbar"></header>
+
+  <div class="objbar">
+    <h1>SN 2023ixf</h1>
+    <span class="chip brand">SN II</span>
+    <span class="sep"></span>
+    <span id="coords-slot"></span>
+    <span class="sep"></span>
+    <span class="chip"><span class="k">z</span> 0.000804</span>
+    <span class="chip"><span class="k">host</span> M101</span>
+    <span class="chip"><span class="k">discovered</span> 2023-05-19</span>
+    <span class="chip"><span class="k">peak</span> 10.9 (o)</span>
+    <span class="chip"><span class="k">sources</span> TNS · ZTF · ATLAS · Sherlock</span>
+  </div>
+
+  <main class="main">
+    <section class="card" id="lc-card">
+      <div class="card-head">
+        <h2 id="lc-title-icon">Lightcurve</h2>
+        <div class="spacer"></div>
+        <div class="seg" id="lc-seg">
+          <button class="active" data-view="plot">Plot</button>
+          <button data-view="table">Table</button>
+        </div>
+      </div>
+      <div class="card-body">
+        <div id="lc-plot" class="plot-host"></div>
+        <div id="lc-table-wrap"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 id="sky-title-icon">Sky view</h2>
+        <div class="spacer"></div>
+        <span class="faint small mono">PanSTARRS DR1 · fov 8.4′</span>
+      </div>
+      <div class="card-body" style="padding:0">
+        <div id="aladin-div" class="aladin-host"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 id="meta-title-icon">Metadata</h2>
+        <div class="spacer"></div>
+        <span class="faint small">4 sources</span>
+      </div>
+      <div class="card-body" style="display:flex;flex-direction:column;padding:10px 14px 12px">
+        <div id="meta-tabs" style="display:flex;flex-direction:column;min-height:0;flex:1"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="statusbar">
+    <button class="btn btn-ghost btn-sm" onclick="openDrawer('tags')" id="btn-tags"></button>
+    <button class="btn btn-ghost btn-sm" onclick="openDrawer('cite')" id="btn-cite"></button>
+    <button class="btn btn-ghost btn-sm" onclick="openDrawer('json')" id="btn-json"></button>
+    <div class="spacer" style="flex:1"></div>
+    <span class="faint">237 detections · 4 sources · updated 2023-09-14 03:12 UTC</span>
+  </footer>
+</div>
+
+<!-- drawers for low-frequency content -->
+<div class="drawer-backdrop" id="backdrop" onclick="closeDrawers()"></div>
+
+<aside class="drawer" id="drawer-tags">
+  <div class="drawer-head">Tags<div class="spacer" style="flex:1"></div>
+    <button class="icon-btn sm" onclick="closeDrawers()">✕</button></div>
+  <div class="drawer-body">
+    <div style="display:flex;flex-wrap:wrap;gap:8px" id="tags-list"></div>
+    <div id="tags-assign"></div>
+  </div>
+</aside>
+
+<aside class="drawer" id="drawer-cite">
+  <div class="drawer-head">Citations<div class="spacer" style="flex:1"></div>
+    <button class="btn btn-outline btn-sm" onclick="copyText(CITATIONS_BIB, this)">Copy BibTeX</button>
+    <button class="icon-btn sm" onclick="closeDrawers()">✕</button></div>
+  <div class="drawer-body"><pre class="codeblock" id="cite-block"></pre></div>
+</aside>
+
+<aside class="drawer" id="drawer-json">
+  <div class="drawer-head">Full metadata (JSON)<div class="spacer" style="flex:1"></div>
+    <button class="btn btn-outline btn-sm" onclick="copyText(fullJsonDump(), this)">Copy</button>
+    <button class="icon-btn sm" onclick="closeDrawers()">✕</button></div>
+  <div class="drawer-body"><pre class="codeblock" id="json-block"></pre></div>
+</aside>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("lightcurve");
+  document.getElementById("coords-slot").innerHTML = coordsCopyHTML();
+  document.getElementById("lc-title-icon").innerHTML = ICONS.curve + " Lightcurve";
+  document.getElementById("sky-title-icon").innerHTML = ICONS.globe + " Sky view";
+  document.getElementById("meta-title-icon").innerHTML = ICONS.table + " Metadata";
+  document.getElementById("btn-tags").innerHTML = ICONS.tag + " Tags (3)";
+  document.getElementById("btn-cite").innerHTML = ICONS.quote + " Citations";
+  document.getElementById("btn-json").innerHTML = ICONS.json + " JSON";
+  document.getElementById("cite-block").textContent = CITATIONS_BIB;
+  document.getElementById("json-block").textContent = fullJsonDump();
+  document.getElementById("tags-list").innerHTML = tagsHTML();
+  document.getElementById("tags-assign").innerHTML = tagAssignHTML();
+
+  mountLightcurve(document.getElementById("lc-plot"), { compact: true });
+  mountAladin(document.getElementById("aladin-div"));
+  mountMetaTabs(document.getElementById("meta-tabs"), "pill");
+
+  /* plot / table toggle */
+  const lcCard = document.getElementById("lc-card");
+  document.querySelectorAll("#lc-seg button").forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll("#lc-seg button").forEach((x) => x.classList.remove("active"));
+      b.classList.add("active");
+      lcCard.classList.toggle("show-table", b.dataset.view === "table");
+      if (b.dataset.view === "table" && !lcCard.dataset.tableBuilt) {
+        document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+        lcCard.dataset.tableBuilt = "1";
+      } else if (b.dataset.view === "plot") {
+        Plotly.Plots.resize(document.getElementById("lc-plot"));
+      }
+    };
+  });
+  onThemeChange(() => { lcCard.dataset.tableBuilt = "";  // rebuild swatches on next open
+    if (lcCard.classList.contains("show-table")) {
+      document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+      lcCard.dataset.tableBuilt = "1";
+    }
+  });
+
+  /* drawers */
+  function openDrawer(which) {
+    closeDrawers();
+    document.getElementById("backdrop").classList.add("open");
+    document.getElementById("drawer-" + which).classList.add("open");
+  }
+  function closeDrawers() {
+    document.querySelectorAll(".drawer, .drawer-backdrop").forEach((d) => d.classList.remove("open"));
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeDrawers(); });
+</script>
+</body>
+</html>

--- a/mockups/mockup-2-balanced.html
+++ b/mockups/mockup-2-balanced.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv mockup 2 — Balanced</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1380px; margin: 0 auto; padding: 18px 22px 40px; }
+
+  .page-head {
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .page-head h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+
+  /* summary strip: the "key metadata without scrolling" answer */
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 18px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+  }
+  .summary .stat { border-left: 1px solid var(--border); padding-left: 16px; }
+  .summary .stat:first-child { border-left: none; padding-left: 0; }
+
+  .hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+    gap: 14px; margin-bottom: 14px;
+  }
+  .hero-grid .card { display: flex; flex-direction: column; }
+  .hero-grid .card-body { flex: 1; min-height: 0; padding: 8px; }
+  #lc-body { height: 430px; }
+  #sky-body { height: 430px; padding: 0; }
+
+  #lc-table-wrap { display: none; overflow: auto; height: 430px; padding: 0 8px; }
+  #lc-card.show-table #lc-table-wrap { display: block; }
+  #lc-card.show-table #lc-body { display: none; }
+
+  .lower-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+    gap: 14px; margin-bottom: 14px;
+    align-items: start;
+  }
+  .stack { display: flex; flex-direction: column; gap: 14px; }
+
+  @media (max-width: 1100px) {
+    .summary { grid-template-columns: repeat(3, 1fr); row-gap: 14px; }
+    .summary .stat:nth-child(4) { border-left: none; padding-left: 0; }
+    .hero-grid, .lower-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <div class="page-head">
+    <h1>SN 2023ixf</h1>
+    <span class="chip brand">SN II</span>
+    <span id="coords-slot"></span>
+    <div style="flex:1"></div>
+    <button class="btn btn-outline btn-sm" onclick="location.hash='#tags'">+ Tag</button>
+    <button class="btn btn-outline btn-sm" onclick="copyText(CITATIONS_BIB, this)">Cite</button>
+  </div>
+
+  <section class="card summary">
+    <div class="stat"><span class="k">Redshift</span><span class="v">0.000804</span></div>
+    <div class="stat"><span class="k">Host</span><span class="v">M101 <span class="unit">(NGC 5457)</span></span></div>
+    <div class="stat"><span class="k">Discovered</span><span class="v">2023-05-19 <span class="unit">Itagaki</span></span></div>
+    <div class="stat"><span class="k">Peak mag</span><span class="v">10.9 <span class="unit">o</span></span></div>
+    <div class="stat"><span class="k">Distance</span><span class="v">6.85 <span class="unit">Mpc</span></span></div>
+    <div class="stat"><span class="k">Detections</span><span class="v">237 <span class="unit">ZTF + ATLAS</span></span></div>
+  </section>
+
+  <div class="hero-grid">
+    <section class="card" id="lc-card">
+      <div class="card-head">
+        <h2 id="lc-title-icon">Lightcurve</h2>
+        <div class="spacer"></div>
+        <div class="seg" id="lc-seg">
+          <button class="active" data-view="plot">Plot</button>
+          <button data-view="table">Table</button>
+        </div>
+      </div>
+      <div class="card-body" id="lc-body"><div id="lc-plot" class="plot-host"></div></div>
+      <div id="lc-table-wrap"></div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 id="sky-title-icon">Sky view</h2>
+        <div class="spacer"></div>
+        <span class="faint small mono">PanSTARRS DR1</span>
+      </div>
+      <div class="card-body" id="sky-body"><div id="aladin-div" class="aladin-host"></div></div>
+    </section>
+  </div>
+
+  <div class="lower-grid">
+    <section class="card">
+      <div class="card-head">
+        <h2 id="meta-title-icon">Source metadata</h2>
+        <div class="spacer"></div>
+        <span class="faint small">TNS · ZTF · ATLAS · Sherlock</span>
+      </div>
+      <div class="card-body" style="padding:6px 16px 16px">
+        <div id="meta-tabs" style="display:flex;flex-direction:column;max-height:420px"></div>
+      </div>
+    </section>
+
+    <div class="stack">
+      <section class="card" id="tags">
+        <div class="card-head"><h2 id="tags-title-icon">Tags</h2></div>
+        <div class="card-body">
+          <div style="display:flex;flex-wrap:wrap;gap:8px" id="tags-list"></div>
+          <div id="tags-assign"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="card-head">
+          <h2 id="cite-title-icon">Citations</h2>
+          <div class="spacer"></div>
+          <button class="btn btn-outline btn-sm" onclick="copyText(CITATIONS_BIB, this)">Copy BibTeX</button>
+        </div>
+        <div class="card-body">
+          <pre class="codeblock" style="max-height:230px" id="cite-block"></pre>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <details class="accordion">
+    <summary id="json-summary"></summary>
+    <div class="accordion-body">
+      <pre class="codeblock" style="max-height:380px" id="json-block"></pre>
+    </div>
+  </details>
+
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("lightcurve");
+  document.getElementById("coords-slot").innerHTML = coordsCopyHTML();
+  document.getElementById("lc-title-icon").innerHTML = ICONS.curve + " Lightcurve";
+  document.getElementById("sky-title-icon").innerHTML = ICONS.globe + " Sky view";
+  document.getElementById("meta-title-icon").innerHTML = ICONS.table + " Source metadata";
+  document.getElementById("tags-title-icon").innerHTML = ICONS.tag + " Tags";
+  document.getElementById("cite-title-icon").innerHTML = ICONS.quote + " Citations";
+  document.getElementById("json-summary").innerHTML = ICONS.chev + " Full metadata (JSON)";
+  document.getElementById("cite-block").textContent = CITATIONS_BIB;
+  document.getElementById("json-block").textContent = fullJsonDump();
+  document.getElementById("tags-list").innerHTML = tagsHTML();
+  document.getElementById("tags-assign").innerHTML = tagAssignHTML();
+
+  mountLightcurve(document.getElementById("lc-plot"));
+  mountAladin(document.getElementById("aladin-div"));
+  mountMetaTabs(document.getElementById("meta-tabs"), "underline");
+
+  const lcCard = document.getElementById("lc-card");
+  document.querySelectorAll("#lc-seg button").forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll("#lc-seg button").forEach((x) => x.classList.remove("active"));
+      b.classList.add("active");
+      const table = b.dataset.view === "table";
+      lcCard.classList.toggle("show-table", table);
+      if (table) document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+      else Plotly.Plots.resize(document.getElementById("lc-plot"));
+    };
+  });
+  onThemeChange(() => {
+    if (lcCard.classList.contains("show-table"))
+      document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+  });
+</script>
+</body>
+</html>

--- a/mockups/mockup-3-spacious.html
+++ b/mockups/mockup-3-spacious.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv mockup 3 — Spacious</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  .container { max-width: 1180px; margin: 0 auto; padding: 0 28px 80px; }
+
+  .hero {
+    padding: 64px 0 40px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 40px;
+  }
+  .hero .eyebrow {
+    font-size: 12px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--primary-ink); margin-bottom: 10px;
+  }
+  .hero h1 { font-size: 44px; font-weight: 800; letter-spacing: -0.03em; line-height: 1.1; }
+  .hero .sub {
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+    margin-top: 16px; color: var(--ink-2); font-size: 15px;
+  }
+  .hero .sub .mono { font-size: 15px; }
+  .hero .facts-row {
+    display: flex; gap: 48px; flex-wrap: wrap; margin-top: 34px;
+  }
+  .hero .stat .v { font-size: 20px; }
+
+  .section { margin-bottom: 56px; }
+  .section-head { margin-bottom: 18px; }
+  .section-head .eyebrow {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--ink-3); margin-bottom: 4px;
+  }
+  .section-head h2 { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+  .section-head p { color: var(--ink-2); margin-top: 4px; max-width: 640px; }
+
+  #lc-body { height: 520px; padding: 12px; }
+  #lc-table-wrap { display: none; max-height: 520px; overflow: auto; padding: 0 12px 12px; }
+  #lc-card.show-table #lc-table-wrap { display: block; }
+  #lc-card.show-table #lc-body { display: none; }
+
+  .sky-grid {
+    display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 20px;
+    align-items: stretch;
+  }
+  #sky-body { height: 480px; padding: 0; }
+  .sky-side { display: flex; flex-direction: column; gap: 20px; }
+
+  .lower-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; align-items: start; }
+
+  @media (max-width: 980px) {
+    .hero h1 { font-size: 34px; }
+    .sky-grid, .lower-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header class="topbar" id="topbar"></header>
+
+<div class="container">
+
+  <section class="hero">
+    <div class="eyebrow">Transient · TXV-2023-051901</div>
+    <h1>SN 2023ixf</h1>
+    <div class="sub">
+      <span class="chip brand">SN II</span>
+      <span id="coords-slot"></span>
+      <span class="faint">J2000</span>
+    </div>
+    <div class="facts-row">
+      <div class="stat"><span class="k">Redshift</span><span class="v">0.000804</span></div>
+      <div class="stat"><span class="k">Host galaxy</span><span class="v">M101</span></div>
+      <div class="stat"><span class="k">Discovered</span><span class="v">2023-05-19</span></div>
+      <div class="stat"><span class="k">Peak magnitude</span><span class="v">10.9 <span class="unit">o</span></span></div>
+      <div class="stat"><span class="k">Distance</span><span class="v">6.85 <span class="unit">Mpc</span></span></div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <div class="eyebrow">Photometry</div>
+      <h2>Lightcurve</h2>
+      <p>237 detections from ZTF and ATLAS spanning 128 days, with pre-discovery
+         non-detection limits. Drag to zoom; double-click to reset.</p>
+    </div>
+    <div class="card" id="lc-card">
+      <div class="card-head">
+        <h2 id="lc-title-icon">ZTF g · r &nbsp;+&nbsp; ATLAS c · o</h2>
+        <div class="spacer"></div>
+        <div class="seg" id="lc-seg">
+          <button class="active" data-view="plot">Plot</button>
+          <button data-view="table">Table</button>
+        </div>
+      </div>
+      <div class="card-body" id="lc-body"><div id="lc-plot" class="plot-host"></div></div>
+      <div id="lc-table-wrap"></div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <div class="eyebrow">Sky context</div>
+      <h2>Field &amp; host association</h2>
+      <p>PanSTARRS DR1 colour imagery centred on the transient. Sherlock associates
+         this object with the nearby spiral M101 at 6.85 Mpc.</p>
+    </div>
+    <div class="sky-grid">
+      <div class="card">
+        <div class="card-body" id="sky-body"><div id="aladin-div" class="aladin-host" style="border-radius:13px"></div></div>
+      </div>
+      <div class="sky-side">
+        <div class="card">
+          <div class="card-head"><h2>Host association</h2></div>
+          <div class="card-body facts" id="sherlock-facts"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <div class="eyebrow">Provenance</div>
+      <h2>Source metadata</h2>
+    </div>
+    <div class="card">
+      <div class="card-body" style="padding:10px 20px 20px">
+        <div id="meta-tabs" style="display:flex;flex-direction:column"></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <div class="eyebrow">Workspace</div>
+      <h2>Tags &amp; citations</h2>
+    </div>
+    <div class="lower-grid">
+      <div class="card">
+        <div class="card-head"><h2 id="tags-title-icon">Tags</h2></div>
+        <div class="card-body">
+          <div style="display:flex;flex-wrap:wrap;gap:8px" id="tags-list"></div>
+          <div id="tags-assign"></div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-head">
+          <h2 id="cite-title-icon">Citations</h2>
+          <div class="spacer"></div>
+          <button class="btn btn-outline btn-sm" onclick="copyText(CITATIONS_BIB, this)">Copy BibTeX</button>
+        </div>
+        <div class="card-body"><pre class="codeblock" style="max-height:260px" id="cite-block"></pre></div>
+      </div>
+    </div>
+  </section>
+
+  <details class="accordion">
+    <summary id="json-summary"></summary>
+    <div class="accordion-body"><pre class="codeblock" style="max-height:400px" id="json-block"></pre></div>
+  </details>
+
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("lightcurve");
+  document.getElementById("coords-slot").innerHTML = coordsCopyHTML();
+  document.getElementById("lc-title-icon").innerHTML = ICONS.curve + " ZTF g · r &nbsp;+&nbsp; ATLAS c · o";
+  document.getElementById("tags-title-icon").innerHTML = ICONS.tag + " Tags";
+  document.getElementById("cite-title-icon").innerHTML = ICONS.quote + " Citations";
+  document.getElementById("json-summary").innerHTML = ICONS.chev + " Full metadata (JSON)";
+  document.getElementById("cite-block").textContent = CITATIONS_BIB;
+  document.getElementById("json-block").textContent = fullJsonDump();
+  document.getElementById("tags-list").innerHTML = tagsHTML();
+  document.getElementById("tags-assign").innerHTML = tagAssignHTML();
+
+  /* Sherlock highlights beside the sky view */
+  const sh = SOURCES.find((s) => s.key === "sherlock").fields;
+  document.getElementById("sherlock-facts").innerHTML =
+    ["Association Type", "Catalogue Object ID", "Best Distance", "Separation (arcsec)", "Physical Separation (kpc)", "Classification Reliability"]
+      .map((k) => `<div class="fact"><span class="k">${k}</span><span class="v">${sh[k]}</span></div>`).join("");
+
+  mountLightcurve(document.getElementById("lc-plot"));
+  mountAladin(document.getElementById("aladin-div"));
+  mountMetaTabs(document.getElementById("meta-tabs"), "underline");
+
+  const lcCard = document.getElementById("lc-card");
+  document.querySelectorAll("#lc-seg button").forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll("#lc-seg button").forEach((x) => x.classList.remove("active"));
+      b.classList.add("active");
+      const table = b.dataset.view === "table";
+      lcCard.classList.toggle("show-table", table);
+      if (table) document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+      else Plotly.Plots.resize(document.getElementById("lc-plot"));
+    };
+  });
+  onThemeChange(() => {
+    if (lcCard.classList.contains("show-table"))
+      document.getElementById("lc-table-wrap").innerHTML = photometryTableHTML();
+  });
+</script>
+</body>
+</html>

--- a/mockups/mockup-4-workspace.html
+++ b/mockups/mockup-4-workspace.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TarXiv mockup 4 — Workspace</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
+<script>
+  try { document.documentElement.dataset.theme = localStorage.getItem("tarxiv-mock-theme") || "light"; } catch (e) {}
+</script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+<script src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+<style>
+  html, body { overflow: hidden; }
+
+  .shell { height: 100vh; display: flex; flex-direction: column; }
+  .work { flex: 1; min-height: 0; display: flex; }
+
+  /* ------------------------------------------------ persistent sidebar */
+  .sidebar {
+    width: 292px; flex-shrink: 0;
+    border-right: 1px solid var(--border);
+    background: var(--card);
+    display: flex; flex-direction: column;
+    overflow-y: auto;
+  }
+  .side-sec { padding: 16px 18px; border-bottom: 1px solid var(--border); }
+  .side-sec h3 {
+    font-size: 10.5px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--ink-3); margin-bottom: 10px;
+  }
+  .obj-title { font-size: 19px; font-weight: 700; letter-spacing: -0.01em; }
+  .obj-id { font-size: 11px; color: var(--ink-3); margin-top: 2px; }
+
+  /* ------------------------------------------------------- main panels */
+  .main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+  .panel-tabs {
+    display: flex; gap: 2px; padding: 8px 12px 0;
+    border-bottom: 1px solid var(--border); background: var(--card);
+    flex-shrink: 0;
+  }
+  .panel-tabs button {
+    font: inherit; font-size: 12.5px; font-weight: 600; color: var(--ink-2);
+    display: inline-flex; align-items: center; gap: 7px;
+    background: transparent; border: none; cursor: pointer;
+    padding: 8px 14px 10px; border-bottom: 2px solid transparent; margin-bottom: -1px;
+    border-radius: 8px 8px 0 0;
+  }
+  .panel-tabs button:hover { color: var(--ink); background: var(--card-2); }
+  .panel-tabs button.active { color: var(--primary-ink); border-bottom-color: var(--primary-ink); background: transparent; }
+  .panel-tabs button svg { opacity: 0.75; }
+
+  .panels { flex: 1; min-height: 0; position: relative; }
+  .panel { position: absolute; inset: 0; padding: 12px; display: none; }
+  .panel.active { display: block; }
+
+  .split { display: grid; grid-template-columns: minmax(0, 58fr) minmax(0, 42fr); gap: 12px; height: 100%; }
+  .split .card { display: flex; flex-direction: column; min-height: 0; }
+  .split .card-body { flex: 1; min-height: 0; padding: 8px; }
+
+  .panel .full-card { height: 100%; display: flex; flex-direction: column; }
+  .panel .full-card .card-body { flex: 1; min-height: 0; overflow: auto; }
+
+  .statusbar {
+    display: flex; align-items: center; gap: 14px;
+    height: 32px; flex-shrink: 0; padding: 0 14px;
+    border-top: 1px solid var(--border); background: var(--card);
+    font-size: 11.5px; color: var(--ink-3);
+  }
+  .statusbar .dot-ok { width: 7px; height: 7px; border-radius: 50%; background: #199e70; }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <header class="topbar" id="topbar"></header>
+
+  <div class="work">
+    <!-- persistent object sidebar -->
+    <aside class="sidebar">
+      <div class="side-sec">
+        <div class="obj-title">SN 2023ixf</div>
+        <div class="obj-id mono">TXV-2023-051901</div>
+        <div style="display:flex;gap:6px;margin-top:10px;flex-wrap:wrap">
+          <span class="chip brand">SN II</span>
+          <span class="chip"><span class="k">z</span> 0.000804</span>
+        </div>
+        <div style="margin-top:12px;font-size:12.5px" id="coords-slot"></div>
+      </div>
+
+      <div class="side-sec">
+        <h3>Key facts</h3>
+        <div class="facts" id="key-facts"></div>
+      </div>
+
+      <div class="side-sec">
+        <h3>Tags</h3>
+        <div style="display:flex;flex-wrap:wrap;gap:6px" id="tags-list"></div>
+        <div id="tags-assign"></div>
+      </div>
+
+      <div class="side-sec" style="border-bottom:none">
+        <h3>Data sources</h3>
+        <div class="facts">
+          <div class="fact"><span class="k">TNS</span><span class="v"><a href="#">2023ixf ↗</a></span></div>
+          <div class="fact"><span class="k">ZTF</span><span class="v"><a href="#">ZTF23aaklqou ↗</a></span></div>
+          <div class="fact"><span class="k">ATLAS</span><span class="v"><a href="#">ATLAS23mtp ↗</a></span></div>
+          <div class="fact"><span class="k">Sherlock</span><span class="v">NGC 5457</span></div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- tabbed main area -->
+    <div class="main">
+      <nav class="panel-tabs" id="panel-tabs"></nav>
+
+      <div class="panels">
+        <div class="panel active" data-panel="overview">
+          <div class="split">
+            <section class="card">
+              <div class="card-head"><h2 id="lc-title-icon">Lightcurve</h2></div>
+              <div class="card-body"><div id="lc-plot" class="plot-host"></div></div>
+            </section>
+            <section class="card">
+              <div class="card-head">
+                <h2 id="sky-title-icon">Sky view</h2>
+                <div class="spacer"></div>
+                <span class="faint small mono">PanSTARRS DR1</span>
+              </div>
+              <div class="card-body" style="padding:0">
+                <div id="aladin-div" class="aladin-host"></div>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div class="panel" data-panel="photometry">
+          <div class="card full-card">
+            <div class="card-head"><h2>Photometry — 237 rows</h2>
+              <div class="spacer"></div>
+              <button class="btn btn-outline btn-sm">Export CSV</button>
+            </div>
+            <div class="card-body" id="phot-table"></div>
+          </div>
+        </div>
+
+        <div class="panel" data-panel="metadata">
+          <div class="card full-card">
+            <div class="card-head"><h2>Source metadata</h2></div>
+            <div class="card-body" style="padding:10px 18px 18px">
+              <div id="meta-tabs" style="display:flex;flex-direction:column;height:100%"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" data-panel="citations">
+          <div class="card full-card">
+            <div class="card-head"><h2>Citations</h2>
+              <div class="spacer"></div>
+              <button class="btn btn-outline btn-sm" onclick="copyText(CITATIONS_BIB, this)">Copy BibTeX</button>
+            </div>
+            <div class="card-body"><pre class="codeblock" style="border:none;background:transparent" id="cite-block"></pre></div>
+          </div>
+        </div>
+
+        <div class="panel" data-panel="json">
+          <div class="card full-card">
+            <div class="card-head"><h2>Full metadata (JSON)</h2>
+              <div class="spacer"></div>
+              <button class="btn btn-outline btn-sm" onclick="copyText(fullJsonDump(), this)">Copy</button>
+            </div>
+            <div class="card-body"><pre class="codeblock" style="border:none;background:transparent" id="json-block"></pre></div>
+          </div>
+        </div>
+      </div>
+
+      <footer class="statusbar">
+        <span class="dot-ok"></span><span>API connected</span>
+        <span>·</span><span>4 sources merged</span>
+        <span style="flex:1"></span>
+        <span>updated 2023-09-14 03:12 UTC</span>
+      </footer>
+    </div>
+  </div>
+</div>
+
+<script src="shared.js"></script>
+<script>
+  document.getElementById("topbar").innerHTML = topbarHTML("lightcurve");
+  document.getElementById("coords-slot").innerHTML = coordsCopyHTML();
+  document.getElementById("lc-title-icon").innerHTML = ICONS.curve + " Lightcurve";
+  document.getElementById("sky-title-icon").innerHTML = ICONS.globe + " Sky view";
+  document.getElementById("cite-block").textContent = CITATIONS_BIB;
+  document.getElementById("json-block").textContent = fullJsonDump();
+  document.getElementById("tags-list").innerHTML = tagsHTML();
+  document.getElementById("tags-assign").innerHTML = tagAssignHTML();
+
+  document.getElementById("key-facts").innerHTML = [
+    ["Host", "M101 (NGC 5457)"], ["Discovered", "2023-05-19"],
+    ["Reporting group", "Itagaki"], ["Peak mag", "10.9 (o)"],
+    ["Distance", "6.85 Mpc"], ["Separation", "263.7″ / 8.76 kpc"],
+    ["Detections", "237"],
+  ].map(([k, v]) => `<div class="fact"><span class="k">${k}</span><span class="v">${v}</span></div>`).join("");
+
+  /* panel tabs */
+  const PANELS = [
+    ["overview", "Overview", ICONS.curve],
+    ["photometry", "Photometry", ICONS.table],
+    ["metadata", "Metadata", ICONS.table],
+    ["citations", "Citations", ICONS.quote],
+    ["json", "JSON", ICONS.json],
+  ];
+  const tabsEl = document.getElementById("panel-tabs");
+  for (const [key, label, icon] of PANELS) {
+    const b = document.createElement("button");
+    b.innerHTML = icon + " " + label;
+    b.dataset.key = key;
+    if (key === "overview") b.classList.add("active");
+    b.onclick = () => {
+      tabsEl.querySelectorAll("button").forEach((x) => x.classList.toggle("active", x === b));
+      document.querySelectorAll(".panel").forEach((p) =>
+        p.classList.toggle("active", p.dataset.panel === key));
+      if (key === "overview") Plotly.Plots.resize(document.getElementById("lc-plot"));
+      if (key === "photometry" && !tabsEl.dataset.photBuilt) {
+        document.getElementById("phot-table").innerHTML = photometryTableHTML();
+        tabsEl.dataset.photBuilt = "1";
+      }
+    };
+    tabsEl.appendChild(b);
+  }
+  onThemeChange(() => {
+    if (tabsEl.dataset.photBuilt)
+      document.getElementById("phot-table").innerHTML = photometryTableHTML();
+  });
+
+  mountLightcurve(document.getElementById("lc-plot"), { compact: true });
+  mountAladin(document.getElementById("aladin-div"));
+  mountMetaTabs(document.getElementById("meta-tabs"), "underline");
+</script>
+</body>
+</html>

--- a/mockups/shared.css
+++ b/mockups/shared.css
@@ -357,3 +357,88 @@ details.accordion .accordion-body { padding: 0 16px 16px; }
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 5px; border: 2px solid transparent; background-clip: content-box; }
 ::-webkit-scrollbar-track { background: transparent; }
+
+/* ==========================================================================
+   Cone search — shared by cone-1..4
+   ========================================================================== */
+
+/* ------------------------------------------------------- compressed bar */
+
+.cone-bar { padding: 12px 16px 13px; }
+
+.cone-bar-top { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.cone-bar-top .spacer { flex: 1; }
+.cone-bar-title {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px; font-weight: 600; color: var(--ink);
+}
+.cone-bar-title svg { color: var(--ink-3); }
+
+.cone-bar-fields { display: flex; align-items: flex-end; gap: 10px; flex-wrap: wrap; }
+.cone-bar-fields .spacer { flex: 1; }
+
+.cone-field { display: flex; flex-direction: column; gap: 3px; position: relative; }
+.cone-field .lab {
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.07em;
+  text-transform: uppercase; color: var(--ink-3);
+}
+.cone-field input {
+  font: inherit; font-size: 13px; font-weight: 500;
+  height: 34px; padding: 0 10px;
+  color: var(--ink); background: var(--card);
+  border: 1px solid var(--border-strong); border-radius: 9px;
+  outline: none; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.cone-field input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-soft); }
+.cone-field.ra input { width: 168px; }
+.cone-field.dec input { width: 168px; }
+.cone-field.rad input { width: 92px; padding-right: 22px; }
+.cone-field .unit {
+  position: absolute; right: 9px; bottom: 8px;
+  font-style: normal; font-size: 12px; color: var(--ink-3); pointer-events: none;
+}
+.cone-hint { align-self: center; }
+
+.cone-summary { font-size: 13px; color: var(--ink-2); padding: 2px 2px 0; }
+.cone-summary b { color: var(--ink); font-weight: 700; }
+
+/* --------------------------------------------------------- result pieces */
+
+.spark { display: block; }
+
+.band-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10.5px; font-weight: 600; color: var(--ink-2);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+.band-chip i { width: 7px; height: 7px; border-radius: 2px; display: block; }
+.band-chips { display: flex; gap: 7px; }
+
+.obj-name {
+  font-size: 14.5px; font-weight: 700; letter-spacing: -0.01em; color: var(--ink);
+}
+.obj-name:hover { color: var(--primary-ink); }
+.alias { font-size: 11px; color: var(--ink-3); margin-left: 7px; }
+
+.type-chip { font-size: 11px; padding: 2px 8px; }
+.tag-chip { font-size: 11px; padding: 2px 8px; border-style: solid; border-width: 1px; }
+
+.src-pill {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.03em;
+  color: var(--ink-3); background: var(--card-2);
+  border-radius: 4px; padding: 1px 5px;
+}
+.src-pills { display: flex; gap: 4px; flex-wrap: wrap; }
+
+.sep-val {
+  font-size: 13px; font-weight: 700; color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.sep-lab { font-size: 10px; font-weight: 600; letter-spacing: 0.07em;
+  text-transform: uppercase; color: var(--ink-3); }
+
+/* inline k/v pairs used across the row and card layouts */
+.kv { display: flex; align-items: baseline; gap: 5px; font-size: 12px; white-space: nowrap; }
+.kv .k { color: var(--ink-3); }
+.kv .v { color: var(--ink); font-weight: 600; font-variant-numeric: tabular-nums; }
+.kv-row { display: flex; gap: 14px; flex-wrap: wrap; }

--- a/mockups/shared.css
+++ b/mockups/shared.css
@@ -1,0 +1,359 @@
+/* ==========================================================================
+   TarXiv redesign mockups — shared design tokens + components
+   Palette: refined arXiv red (#b31b1b) + neutral surfaces, light & dark.
+   Filter (chart) colours are defined in shared.js and validated with the
+   dataviz palette validator against both card surfaces (see mockups/index.html).
+   ========================================================================== */
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f7f7f8;
+  --card: #ffffff;
+  --card-2: #f2f2f4;          /* inset panels, code blocks   */
+  --border: rgba(18, 22, 23, 0.10);
+  --border-strong: rgba(18, 22, 23, 0.18);
+  --ink: #15191b;
+  --ink-2: #5a6166;
+  --ink-3: #8b9196;
+  --primary: #b31b1b;         /* arXiv red — brand           */
+  --primary-hover: #971616;
+  --primary-ink: #b31b1b;     /* red used AS text            */
+  --primary-soft: rgba(179, 27, 27, 0.07);
+  --primary-soft-2: rgba(179, 27, 27, 0.14);
+  --grid: #ececef;            /* plot gridlines              */
+  --axis: #c9ccd0;
+  --shadow: 0 1px 2px rgba(18, 22, 23, 0.05), 0 4px 16px rgba(18, 22, 23, 0.05);
+  --shadow-lg: 0 4px 12px rgba(18, 22, 23, 0.08), 0 12px 40px rgba(18, 22, 23, 0.10);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #121617;
+  --card: #1c2224;
+  --card-2: #242c2f;
+  --border: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --ink: #f2f4f5;
+  --ink-2: #a9b2b7;
+  --ink-3: #737d82;
+  --primary: #b31b1b;
+  --primary-hover: #cb2a2a;
+  --primary-ink: #e06058;     /* red text needs a lighter step on dark */
+  --primary-soft: rgba(224, 96, 88, 0.10);
+  --primary-soft-2: rgba(224, 96, 88, 0.18);
+  --grid: #262e31;
+  --axis: #3d4649;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 4px 16px rgba(0, 0, 0, 0.25);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.35), 0 12px 40px rgba(0, 0, 0, 0.40);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
+
+body {
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+a { color: var(--primary-ink); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* --------------------------------------------------------------- top bar */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 0 20px;
+  height: 52px;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.wordmark {
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.wordmark .x { color: var(--primary-ink); }
+.wordmark:hover { text-decoration: none; }
+
+.topnav { display: flex; gap: 2px; }
+.topnav a {
+  color: var(--ink-2);
+  font-weight: 500;
+  font-size: 13px;
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+.topnav a:hover { color: var(--ink); background: var(--card-2); text-decoration: none; }
+.topnav a.active { color: var(--primary-ink); background: var(--primary-soft); }
+
+.topbar .spacer { flex: 1; }
+
+/* ------------------------------------------------------------- controls */
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 0 10px;
+  height: 34px;
+  min-width: 220px;
+  transition: border-color 0.15s;
+}
+.search-box:focus-within { border-color: var(--primary-ink); }
+.search-box svg { flex-shrink: 0; color: var(--ink-3); }
+.search-box input {
+  border: none; outline: none; background: transparent;
+  color: var(--ink); font: inherit; font-size: 13px; width: 100%;
+}
+.search-box input::placeholder { color: var(--ink-3); }
+.search-box kbd {
+  font-family: inherit; font-size: 10.5px; color: var(--ink-3);
+  border: 1px solid var(--border-strong); border-radius: 4px;
+  padding: 1px 5px; white-space: nowrap;
+}
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  font: inherit; font-size: 13px; font-weight: 600;
+  border-radius: 9px; border: 1px solid transparent;
+  padding: 0 14px; height: 34px; cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  color: var(--ink); background: transparent;
+  white-space: nowrap;
+}
+.btn-primary { background: var(--primary); color: #fff; }
+.btn-primary:hover { background: var(--primary-hover); }
+.btn-outline { border-color: var(--border-strong); color: var(--ink-2); }
+.btn-outline:hover { border-color: var(--ink-3); color: var(--ink); }
+.btn-ghost { color: var(--ink-2); }
+.btn-ghost:hover { background: var(--card-2); color: var(--ink); }
+.btn-sm { height: 28px; padding: 0 10px; font-size: 12px; border-radius: 7px; }
+
+.icon-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 9px;
+  border: none; background: transparent; color: var(--ink-2); cursor: pointer;
+}
+.icon-btn:hover { background: var(--card-2); color: var(--ink); }
+.icon-btn.sm { width: 26px; height: 26px; border-radius: 7px; }
+
+/* theme toggle shows the icon of the mode it would switch TO */
+:root[data-theme="light"] .icon-sun { display: none; }
+:root[data-theme="dark"] .icon-moon { display: none; }
+
+/* ----------------------------------------------------------------- cards */
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+}
+
+.card-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.card-head h2 {
+  font-size: 13px; font-weight: 600; letter-spacing: 0.01em;
+  color: var(--ink); display: flex; align-items: center; gap: 8px;
+}
+.card-head h2 svg { color: var(--ink-3); }
+.card-head .spacer { flex: 1; }
+.card-body { padding: 16px; }
+
+/* ------------------------------------------------------------ chips etc. */
+
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; font-weight: 600;
+  padding: 3px 10px; border-radius: 999px;
+  background: var(--card-2); color: var(--ink-2);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+.chip.brand { background: var(--primary-soft); color: var(--primary-ink); border-color: transparent; }
+.chip .dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.chip .k { font-weight: 500; color: var(--ink-3); }
+
+.badge-x {
+  border: none; background: transparent; cursor: pointer; color: inherit;
+  opacity: 0.6; font-size: 13px; line-height: 1; padding: 0 0 0 2px;
+}
+.badge-x:hover { opacity: 1; }
+
+/* ------------------------------------------------------------- key facts */
+
+.facts { display: grid; gap: 0; }
+.fact {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 12px;
+  padding: 7px 0; border-bottom: 1px solid var(--border);
+}
+.fact:last-child { border-bottom: none; }
+.fact .k { color: var(--ink-3); font-size: 12px; font-weight: 500; flex-shrink: 0; }
+.fact .v { color: var(--ink); font-size: 12.5px; font-weight: 500; text-align: right; overflow-wrap: anywhere; }
+
+/* stat tiles (summary strip) */
+.stat {
+  display: flex; flex-direction: column; gap: 2px; min-width: 0;
+}
+.stat .k {
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.07em;
+  text-transform: uppercase; color: var(--ink-3);
+}
+.stat .v { font-size: 15px; font-weight: 600; color: var(--ink); white-space: nowrap; }
+.stat .v .unit { font-size: 12px; color: var(--ink-2); font-weight: 500; }
+
+/* ------------------------------------------------------------------ tabs */
+
+.tabs { display: flex; gap: 2px; flex-wrap: wrap; }
+.tabs button {
+  font: inherit; font-size: 12.5px; font-weight: 600;
+  color: var(--ink-2); background: transparent;
+  border: none; border-radius: 8px; padding: 6px 12px; cursor: pointer;
+}
+.tabs button:hover { color: var(--ink); background: var(--card-2); }
+.tabs button.active { color: var(--primary-ink); background: var(--primary-soft); }
+
+.tabs.underline { gap: 0; border-bottom: 1px solid var(--border); flex-wrap: nowrap; }
+.tabs.underline button {
+  border-radius: 0; padding: 9px 14px;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.tabs.underline button:hover { background: transparent; }
+.tabs.underline button.active {
+  background: transparent; border-bottom-color: var(--primary-ink);
+}
+
+/* --------------------------------------------------------------- tables */
+
+.meta-rows { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.meta-rows td { padding: 6px 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.meta-rows tr:last-child td { border-bottom: none; }
+.meta-rows td.k { color: var(--ink-3); font-weight: 500; width: 42%; }
+.meta-rows td.v { color: var(--ink); font-weight: 500; }
+
+.data-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.data-table th {
+  text-align: left; font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--ink-3);
+  padding: 8px 10px; border-bottom: 1px solid var(--border-strong);
+  position: sticky; top: 0; background: var(--card);
+}
+.data-table td {
+  padding: 6px 10px; border-bottom: 1px solid var(--border);
+  color: var(--ink); font-variant-numeric: tabular-nums;
+}
+.data-table td .swatch {
+  display: inline-block; width: 9px; height: 9px; border-radius: 3px;
+  margin-right: 7px; vertical-align: 0;
+}
+
+/* ------------------------------------------------------------ code block */
+
+.codeblock {
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--ink-2);
+  overflow: auto;
+  white-space: pre;
+}
+
+/* --------------------------------------------------------------- widgets */
+
+.plot-host { width: 100%; height: 100%; min-height: 0; }
+
+.aladin-host {
+  width: 100%; height: 100%; min-height: 0;
+  border-radius: 0 0 13px 13px; overflow: hidden;
+  background: #0b0d10;                    /* sky is dark in both themes */
+  position: relative;
+}
+.aladin-fallback {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 6px;
+  color: #9aa5ad; font-size: 12.5px; text-align: center; padding: 20px;
+}
+
+/* segmented control (plot / table toggle) */
+.seg {
+  display: inline-flex; background: var(--card-2);
+  border: 1px solid var(--border); border-radius: 8px; padding: 2px;
+}
+.seg button {
+  font: inherit; font-size: 11.5px; font-weight: 600; color: var(--ink-2);
+  background: transparent; border: none; border-radius: 6px;
+  padding: 3px 10px; cursor: pointer;
+}
+.seg button.active { background: var(--card); color: var(--ink); box-shadow: var(--shadow); }
+
+/* ------------------------------------------------------------- accordion */
+
+details.accordion { border: 1px solid var(--border); border-radius: 12px; background: var(--card); }
+details.accordion > summary {
+  list-style: none; cursor: pointer; display: flex; align-items: center; gap: 8px;
+  padding: 12px 16px; font-size: 13px; font-weight: 600; color: var(--ink-2);
+}
+details.accordion > summary::-webkit-details-marker { display: none; }
+details.accordion > summary .chev { transition: transform 0.15s; color: var(--ink-3); }
+details.accordion[open] > summary .chev { transform: rotate(90deg); }
+details.accordion .accordion-body { padding: 0 16px 16px; }
+
+/* --------------------------------------------------------------- drawer */
+
+.drawer-backdrop {
+  position: fixed; inset: 0; background: rgba(10, 12, 13, 0.45);
+  opacity: 0; pointer-events: none; transition: opacity 0.2s; z-index: 200;
+}
+.drawer {
+  position: fixed; top: 0; right: 0; bottom: 0; width: min(440px, 92vw);
+  background: var(--card); border-left: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  transform: translateX(100%); transition: transform 0.22s ease; z-index: 201;
+  display: flex; flex-direction: column;
+}
+.drawer.open { transform: translateX(0); }
+.drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+.drawer-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px; border-bottom: 1px solid var(--border);
+  font-weight: 600; font-size: 14px;
+}
+.drawer-body { padding: 18px; overflow: auto; flex: 1; }
+
+/* -------------------------------------------------------------- helpers */
+
+.scroll-y { overflow-y: auto; min-height: 0; }
+.muted { color: var(--ink-2); }
+.faint { color: var(--ink-3); }
+.small { font-size: 12px; }
+
+.copy-wrap { display: inline-flex; align-items: center; gap: 6px; }
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 5px; border: 2px solid transparent; background-clip: content-box; }
+::-webkit-scrollbar-track { background: transparent; }

--- a/mockups/shared.js
+++ b/mockups/shared.js
@@ -1,0 +1,494 @@
+/* ==========================================================================
+   TarXiv redesign mockups — shared data + widget builders
+   ========================================================================== */
+
+/* ------------------------------------------------------------ theme utils */
+
+const THEME_KEY = "tarxiv-mock-theme";
+
+function currentTheme() {
+  return document.documentElement.dataset.theme || "light";
+}
+
+const themeListeners = [];
+function onThemeChange(fn) { themeListeners.push(fn); }
+
+function toggleTheme() {
+  const next = currentTheme() === "light" ? "dark" : "light";
+  document.documentElement.dataset.theme = next;
+  try { localStorage.setItem(THEME_KEY, next); } catch (e) { /* ignore */ }
+  themeListeners.forEach((fn) => fn(next));
+}
+
+/* Chart chrome per theme (mirrors shared.css tokens — Plotly can't read CSS vars) */
+const CHART_CHROME = {
+  light: {
+    surface: "#ffffff", ink: "#15191b", ink2: "#5a6166", ink3: "#8b9196",
+    grid: "#ececef", axis: "#c9ccd0",
+  },
+  dark: {
+    surface: "#1c2224", ink: "#f2f4f5", ink2: "#a9b2b7", ink3: "#737d82",
+    grid: "#262e31", axis: "#3d4649",
+  },
+};
+
+/* Filter colours — validated with the dataviz palette validator (all-pairs,
+   scatter) against #ffffff (light) and #1c2224 (dark). Marker symbols are the
+   secondary encoding for the warn-band CVD pairs; the photometry table is the
+   relief channel for the light-mode amber. */
+const FILTER_STYLE = {
+  "ZTF g":   { light: "#199e70", dark: "#199e70", symbol: "circle" },
+  "ZTF r":   { light: "#e34948", dark: "#e34948", symbol: "square" },
+  "ATLAS c": { light: "#2a78d6", dark: "#3987e5", symbol: "diamond" },
+  "ATLAS o": { light: "#eda100", dark: "#c98500", symbol: "triangle-up" },
+};
+
+/* ------------------------------------------------------------ sample data */
+
+/* SN 2023ixf in M101 — real object, plausible fabricated photometry. */
+const OBJ = {
+  id: "SN 2023ixf",
+  tarxiv_id: "TXV-2023-051901",
+  ra_deg: 210.910674,
+  dec_deg: 54.31165,
+  ra_hms: "14:03:38.56",
+  dec_dms: "+54:18:41.9",
+  type: "SN II",
+  redshift: 0.000804,
+  host: "M101 (NGC 5457)",
+  discovery_date: "2023-05-19 17:27:15",
+  discovery_mjd: 60083.727,
+  reporting_group: "Itagaki",
+  discovery_source: "Itagaki (ALeRCE)",
+  peak_mag: "10.9 (o)",
+  update_date: "2023-09-14 03:12:44",
+};
+
+function mulberry32(seed) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/* Type II-P-ish model: fast rise, slow plateau, drop-off. */
+function modelMag(mjd, offset) {
+  const t = mjd - OBJ.discovery_mjd;
+  const peak = 11.05 + offset;
+  if (t < 0) return NaN;
+  if (t < 6) return peak + 3.4 * Math.pow(1 - t / 6, 1.7); // rise
+  if (t < 85) return peak + 0.011 * (t - 6);               // plateau
+  return peak + 0.011 * 79 + 0.055 * (t - 85);             // decline
+}
+
+function genPhotometry() {
+  const rng = mulberry32(20230519);
+  const series = [];
+  const cfg = [
+    { name: "ZTF g",   survey: "ZTF",   offset: 0.55, cadence: 2.4, start: 0.9 },
+    { name: "ZTF r",   survey: "ZTF",   offset: 0.18, cadence: 2.4, start: 1.1 },
+    { name: "ATLAS c", survey: "ATLAS", offset: 0.34, cadence: 3.1, start: 0.4 },
+    { name: "ATLAS o", survey: "ATLAS", offset: 0.0,  cadence: 3.1, start: 0.2 },
+  ];
+  for (const c of cfg) {
+    const det = { x: [], y: [], err: [] };
+    let t = c.start;
+    while (t < 128) {
+      if (rng() > 0.18) { // weather losses
+        const mjd = OBJ.discovery_mjd + t + (rng() - 0.5) * 0.6;
+        const m = modelMag(mjd, c.offset);
+        if (!Number.isNaN(m)) {
+          const err = 0.015 + 0.012 * Math.max(0, m - 11) + rng() * 0.02;
+          det.x.push(+mjd.toFixed(3));
+          det.y.push(+(m + (rng() - 0.5) * 2 * err * 1.4).toFixed(3));
+          det.err.push(+err.toFixed(3));
+        }
+      }
+      t += c.cadence * (0.75 + rng() * 0.5);
+    }
+    /* pre-discovery non-detection limits */
+    const lim = { x: [], y: [] };
+    let tl = -14 + rng() * 2;
+    while (tl < -0.6) {
+      lim.x.push(+(OBJ.discovery_mjd + tl).toFixed(3));
+      lim.y.push(+(19.1 + rng() * 0.8 - c.offset * 0.3).toFixed(2));
+      tl += c.cadence * (0.8 + rng() * 0.5);
+    }
+    series.push({ ...c, det, lim });
+  }
+  return series;
+}
+
+const PHOTOMETRY = genPhotometry();
+
+/* ---------------------------------------------------------- metadata dump */
+
+const SOURCES = [
+  {
+    key: "tns", label: "TNS",
+    fields: {
+      "Identifier": "2023ixf",
+      "Object Type": "SN II",
+      "Discovery Date": "2023-05-19 17:27:15",
+      "Reporting Group": "Itagaki",
+      "Discovery Data Source": "ALeRCE",
+      "Redshift": "0.000804",
+      "Host Name": "M101 (NGC 5457)",
+      "Magnitude": "14.90",
+      "Magnitude Filter": "Clear",
+      "RA (deg)": "210.910674",
+      "Dec (deg)": "54.311650",
+    },
+  },
+  {
+    key: "ztf", label: "ZTF",
+    fields: {
+      "Identifier": "ZTF23aaklqou",
+      "RA (deg)": "210.910671",
+      "Dec (deg)": "54.311646",
+      "Detections": "141",
+      "First Detection (MJD)": "60084.16",
+      "Latest Detection (MJD)": "60211.42",
+    },
+    lists: {
+      "Peak Magnitude": [
+        { Filter: "g", Date: "60090.21", Magnitude: "11.58", "Mag Rate": "−0.42" },
+        { Filter: "r", Date: "60090.24", Magnitude: "11.21", "Mag Rate": "−0.38" },
+      ],
+      "Latest Detection": [
+        { Filter: "g", Date: "60211.38", Magnitude: "14.62", "Mag Rate": "+0.05" },
+        { Filter: "r", Date: "60211.42", Magnitude: "13.94", "Mag Rate": "+0.05" },
+      ],
+    },
+  },
+  {
+    key: "atlas", label: "ATLAS",
+    fields: {
+      "Identifier": "ATLAS23mtp",
+      "RA (deg)": "210.910668",
+      "Dec (deg)": "54.311654",
+      "Detections": "96",
+      "First Detection (MJD)": "60083.94",
+      "Latest Detection (MJD)": "60209.87",
+    },
+    lists: {
+      "Peak Magnitude": [
+        { Filter: "c", Date: "60089.97", Magnitude: "11.39", "Mag Rate": "−0.35" },
+        { Filter: "o", Date: "60090.01", Magnitude: "10.94", "Mag Rate": "−0.33" },
+      ],
+      "Latest Non-detection": [
+        { Filter: "o", Date: "60082.91", Magnitude: "> 19.24", "Mag Rate": "—" },
+      ],
+    },
+  },
+  {
+    key: "sherlock", label: "Sherlock",
+    fields: {
+      "Association Type": "SN",
+      "Catalogue Object ID": "NGC 5457",
+      "Catalogue Object Type": "galaxy",
+      "Catalogue Table": "NED-D/GLADE",
+      "Classification Reliability": "1",
+      "Best Distance": "6.85 Mpc",
+      "Best Distance Flag": "z-independent",
+      "Best Distance Source": "NED-D (TRGB)",
+      "Separation (arcsec)": "263.7",
+      "North Separation (arcsec)": "−134.2",
+      "East Separation (arcsec)": "+226.9",
+      "Physical Separation (kpc)": "8.76",
+    },
+  },
+];
+
+const TAGS = [
+  { name: "followup", color: "#b31b1b", owner: "personal" },
+  { name: "SN II", color: "#2a78d6", owner: "team · FTX" },
+  { name: "bright", color: "#c98500", owner: "team · FTX" },
+];
+
+const CITATIONS_BIB = `@article{2019PASP..131a8002B,
+  author = {{Bellm}, Eric C. and {Kulkarni}, Shrinivas R. and et al.},
+  title = "{The Zwicky Transient Facility: System Overview}",
+  journal = {PASP}, year = 2019, volume = {131}, pages = {018002},
+  doi = {10.1088/1538-3873/aaecbe}
+}
+@article{2018PASP..130f4505T,
+  author = {{Tonry}, J.~L. and {Denneau}, L. and et al.},
+  title = "{ATLAS: A High-cadence All-sky Survey System}",
+  journal = {PASP}, year = 2018, volume = {130}, pages = {064505},
+  doi = {10.1088/1538-3873/aabadf}
+}
+@article{2020PASP..132h5002S,
+  author = {{Smith}, K.~W. and {Williams}, R.~D. and et al.},
+  title = "{Design and Operation of the ATLAS Transient Science Server}",
+  journal = {PASP}, year = 2020, volume = {132}, pages = {085002},
+  doi = {10.1088/1538-3873/ab936e}
+}`;
+
+function fullJsonDump() {
+  const doc = {
+    tarxiv_id: OBJ.tarxiv_id, source: "tns", source_id: "2023ixf",
+    ra_deg: OBJ.ra_deg, dec_deg: OBJ.dec_deg,
+    ra_hms: OBJ.ra_hms, dec_dms: OBJ.dec_dms,
+    discovery_date: OBJ.discovery_date, update_date: OBJ.update_date,
+    data_sources: Object.fromEntries(
+      SOURCES.map((s) => [s.key, { ...s.fields, ...(s.lists || {}) }])
+    ),
+  };
+  return JSON.stringify(doc, null, 2);
+}
+
+/* -------------------------------------------------------------- lightcurve */
+
+function lightcurveTraces(theme) {
+  const traces = [];
+  for (const s of PHOTOMETRY) {
+    const st = FILTER_STYLE[s.name];
+    const color = st[theme];
+    traces.push({
+      x: s.det.x, y: s.det.y,
+      error_y: { type: "data", array: s.det.err, visible: true, width: 0, thickness: 1.2, color },
+      mode: "markers", type: "scatter",
+      name: s.name,
+      legendgroup: s.survey, legendgrouptitle: { text: s.survey },
+      marker: { color, size: 8, symbol: st.symbol,
+                line: { width: 1, color: CHART_CHROME[theme].surface } },
+      hovertemplate: `<b>${s.name}</b>  MJD %{x:.2f}<br>%{y:.2f} ± %{customdata:.2f} mag` +
+        `<extra></extra>`,
+      customdata: s.det.err,
+    });
+    if (s.lim.x.length) {
+      traces.push({
+        x: s.lim.x, y: s.lim.y,
+        mode: "markers", type: "scatter",
+        name: `${s.name} limit`,
+        legendgroup: s.survey, showlegend: false,
+        marker: { color, size: 9, symbol: "triangle-down-open", opacity: 0.55 },
+        hovertemplate: `<b>${s.name}</b> non-detection  MJD %{x:.2f}<br>limit %{y:.2f} mag<extra></extra>`,
+      });
+    }
+  }
+  return traces;
+}
+
+function lightcurveLayout(theme, opts = {}) {
+  const c = CHART_CHROME[theme];
+  const compact = !!opts.compact;
+  return {
+    paper_bgcolor: c.surface,
+    plot_bgcolor: c.surface,
+    font: { family: "Inter, system-ui, sans-serif", size: 12, color: c.ink2 },
+    margin: { l: 52, r: 12, t: compact ? 8 : 12, b: 42 },
+    xaxis: {
+      title: { text: "MJD", font: { size: 11, color: c.ink3 }, standoff: 8 },
+      tickformat: "d",
+      gridcolor: c.grid, zeroline: false, linecolor: c.axis,
+      ticks: "outside", tickcolor: c.axis, ticklen: 4,
+      tickfont: { size: 11, color: c.ink3 },
+    },
+    yaxis: {
+      title: { text: "Apparent magnitude", font: { size: 11, color: c.ink3 }, standoff: 6 },
+      autorange: "reversed",
+      gridcolor: c.grid, zeroline: false, linecolor: c.axis,
+      ticks: "outside", tickcolor: c.axis, ticklen: 4,
+      tickfont: { size: 11, color: c.ink3 },
+    },
+    legend: {
+      orientation: "h", x: 0, y: 1.02, xanchor: "left", yanchor: "bottom",
+      font: { size: 11.5, color: c.ink2 },
+      grouptitlefont: { size: 11, color: c.ink3 },
+      itemsizing: "constant",
+    },
+    hoverlabel: {
+      bgcolor: theme === "light" ? "#15191b" : "#f2f4f5",
+      font: { color: theme === "light" ? "#f2f4f5" : "#15191b", size: 12,
+              family: "Inter, system-ui, sans-serif" },
+      bordercolor: "transparent",
+    },
+    dragmode: "zoom",
+    showlegend: true,
+  };
+}
+
+function mountLightcurve(el, opts = {}) {
+  if (typeof Plotly === "undefined") {
+    el.innerHTML = `<div class="aladin-fallback" style="position:static;height:100%">
+      Plotly failed to load (offline?) — lightcurve preview unavailable.</div>`;
+    return;
+  }
+  const cfg = { responsive: true, displaylogo: false,
+                modeBarButtonsToRemove: ["lasso2d", "select2d", "autoScale2d"] };
+  const draw = (theme) =>
+    Plotly.react(el, lightcurveTraces(theme), lightcurveLayout(theme, opts), cfg);
+  draw(currentTheme());
+  onThemeChange(draw);
+}
+
+/* photometry table — the relief channel for sub-3:1 marks + accessibility */
+function photometryTableHTML() {
+  const theme = currentTheme();
+  const rows = [];
+  for (const s of PHOTOMETRY) {
+    const color = FILTER_STYLE[s.name][theme];
+    s.det.x.forEach((x, i) => rows.push({
+      mjd: x, filter: s.name, color,
+      mag: s.det.y[i].toFixed(2), err: s.det.err[i].toFixed(2), kind: "detection",
+    }));
+    s.lim.x.forEach((x, i) => rows.push({
+      mjd: x, filter: s.name, color,
+      mag: "> " + s.lim.y[i].toFixed(2), err: "—", kind: "limit",
+    }));
+  }
+  rows.sort((a, b) => a.mjd - b.mjd);
+  return `<table class="data-table">
+    <thead><tr><th>MJD</th><th>Filter</th><th>Mag</th><th>σ</th><th>Type</th></tr></thead>
+    <tbody>${rows.map((r) => `<tr>
+      <td class="mono">${r.mjd.toFixed(2)}</td>
+      <td><span class="swatch" style="background:${r.color}"></span>${r.filter}</td>
+      <td class="mono">${r.mag}</td><td class="mono">${r.err}</td>
+      <td class="faint">${r.kind}</td></tr>`).join("")}
+    </tbody></table>`;
+}
+
+/* ---------------------------------------------------------------- aladin */
+
+function mountAladin(el) {
+  const fallback = () => {
+    el.innerHTML = `<div class="aladin-fallback">
+      <strong>Aladin Lite unavailable</strong>
+      <span>CDN script did not load — sky view shows here<br>
+      (PanSTARRS DR1 colour, centred on ${OBJ.id})</span></div>`;
+  };
+  if (typeof A === "undefined") { fallback(); return; }
+  A.init.then(() => {
+    const aladin = A.aladin(el, {
+      survey: "P/PanSTARRS/DR1/color-z-zg-g",
+      target: `${OBJ.ra_deg} ${OBJ.dec_deg}`,
+      fov: 0.14,
+      showFullscreenControl: true,
+      showLayersControl: false,
+      showFrame: false,
+      showCooGridControl: false,
+      reticleColor: "#e34948",
+      reticleSize: 26,
+    });
+    const cat = A.catalog({ shape: "circle", color: "#e34948", sourceSize: 16 });
+    aladin.addCatalog(cat);
+    cat.addSources([A.source(OBJ.ra_deg, OBJ.dec_deg, { name: OBJ.id })]);
+  }).catch(fallback);
+}
+
+/* -------------------------------------------------- metadata tab builders */
+
+function metaListTable(title, rows) {
+  const cols = Object.keys(rows[0]);
+  return `<div style="margin-top:12px">
+    <div class="faint small" style="font-weight:600;letter-spacing:.05em;text-transform:uppercase;font-size:10.5px;margin-bottom:4px">${title}</div>
+    <table class="data-table">
+      <thead><tr>${cols.map((c) => `<th>${c}</th>`).join("")}</tr></thead>
+      <tbody>${rows.map((r) =>
+        `<tr>${cols.map((c) => `<td>${r[c]}</td>`).join("")}</tr>`).join("")}
+      </tbody></table></div>`;
+}
+
+function metaFieldsHTML(src) {
+  const rows = Object.entries(src.fields).map(([k, v]) =>
+    `<tr><td class="k">${k}</td><td class="v">${v}</td></tr>`).join("");
+  const lists = src.lists
+    ? Object.entries(src.lists).map(([t, rws]) => metaListTable(t, rws)).join("")
+    : "";
+  return `<table class="meta-rows"><tbody>${rows}</tbody></table>${lists}`;
+}
+
+/* Renders tab buttons + panel into `container`. mode: "pill" | "underline" */
+function mountMetaTabs(container, mode = "pill") {
+  const nav = document.createElement("div");
+  nav.className = "tabs" + (mode === "underline" ? " underline" : "");
+  const panel = document.createElement("div");
+  panel.style.cssText = "margin-top:10px;min-height:0;overflow:auto;flex:1";
+  const select = (key) => {
+    nav.querySelectorAll("button").forEach((b) =>
+      b.classList.toggle("active", b.dataset.key === key));
+    panel.innerHTML = metaFieldsHTML(SOURCES.find((s) => s.key === key));
+  };
+  for (const s of SOURCES) {
+    const b = document.createElement("button");
+    b.textContent = s.label;
+    b.dataset.key = s.key;
+    b.onclick = () => select(s.key);
+    nav.appendChild(b);
+  }
+  container.appendChild(nav);
+  container.appendChild(panel);
+  select("tns");
+}
+
+/* ------------------------------------------------------------------ tags */
+
+function tagsHTML() {
+  return TAGS.map((t) => `<span class="chip" style="background:${t.color}18;border-color:${t.color}40">
+      <span class="dot" style="background:${t.color}"></span>${t.name}
+      <span class="k">${t.owner}</span>
+      <button class="badge-x" title="Remove">×</button></span>`).join(" ");
+}
+
+function tagAssignHTML() {
+  return `<div style="display:flex;gap:8px;margin-top:12px">
+    <div class="search-box" style="min-width:0;flex:1">
+      <input placeholder="Select tag…" list="tag-options">
+      <datalist id="tag-options"><option value="followup"><option value="host-z"><option value="spectrum-needed"></datalist>
+    </div>
+    <button class="btn btn-outline">Assign</button></div>`;
+}
+
+/* -------------------------------------------------------------- misc UI  */
+
+function copyText(text, btn) {
+  navigator.clipboard?.writeText(text).then(() => {
+    if (!btn) return;
+    const old = btn.innerHTML;
+    btn.innerHTML = "✓";
+    setTimeout(() => { btn.innerHTML = old; }, 1200);
+  });
+}
+
+const ICONS = {
+  copy: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`,
+  search: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>`,
+  sun: `<svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>`,
+  moon: `<svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>`,
+  chev: `<svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>`,
+  curve: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 17c4-1 5-9 9-9s5 6 9 5"/></svg>`,
+  globe: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg>`,
+  table: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M9 4v16"/></svg>`,
+  tag: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><path d="M12 2H2v10l9.3 9.3a2 2 0 0 0 2.8 0l7.2-7.2a2 2 0 0 0 0-2.8z"/><circle cx="7" cy="7" r="1.5" fill="currentColor" stroke="none"/></svg>`,
+  quote: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M7 8h10M7 12h6M5 4h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9l-5 4V6a2 2 0 0 1 1-2z"/></svg>`,
+  json: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 4a3 3 0 0 0-3 3v2a3 3 0 0 1-2 3 3 3 0 0 1 2 3v2a3 3 0 0 0 3 3M16 4a3 3 0 0 1 3 3v2a3 3 0 0 0 2 3 3 3 0 0 0-2 3v2a3 3 0 0 1-3 3"/></svg>`,
+};
+
+/* Shared topbar. `active` = nav item key. `variant`: "full" | "slim" */
+function topbarHTML(active = "lightcurve") {
+  const links = [
+    ["home", "Home"], ["lightcurve", "Lightcurve"], ["cone", "Cone Search"],
+    ["alerts", "Alerts"], ["tagged", "Tagged"],
+  ];
+  return `
+    <a class="wordmark" href="index.html">tar<span class="x">X</span>iv</a>
+    <nav class="topnav">${links.map(([k, l]) =>
+      `<a href="#" class="${k === active ? "active" : ""}">${l}</a>`).join("")}
+    </nav>
+    <div class="spacer"></div>
+    <div class="search-box">${ICONS.search}<input placeholder="Search object ID…" value="2023ixf"><kbd>⏎</kbd></div>
+    <button class="icon-btn" onclick="toggleTheme()" title="Toggle theme">${ICONS.sun}${ICONS.moon}</button>
+    <div style="width:30px;height:30px;border-radius:50%;background:var(--primary-soft-2);color:var(--primary-ink);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px" title="Signed in as J. Leland">JL</div>`;
+}
+
+function coordsCopyHTML(id = "coords-copy") {
+  const coords = `${OBJ.ra_hms} ${OBJ.dec_dms}`;
+  return `<span class="copy-wrap">
+    <span class="mono" style="font-weight:600">${coords}</span>
+    <button class="icon-btn sm" id="${id}" title="Copy coordinates"
+      onclick="copyText('${coords}', this)">${ICONS.copy}</button></span>`;
+}

--- a/mockups/shared.js
+++ b/mockups/shared.js
@@ -466,6 +466,8 @@ const ICONS = {
   tag: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><path d="M12 2H2v10l9.3 9.3a2 2 0 0 0 2.8 0l7.2-7.2a2 2 0 0 0 0-2.8z"/><circle cx="7" cy="7" r="1.5" fill="currentColor" stroke="none"/></svg>`,
   quote: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M7 8h10M7 12h6M5 4h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9l-5 4V6a2 2 0 0 1 1-2z"/></svg>`,
   json: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 4a3 3 0 0 0-3 3v2a3 3 0 0 1-2 3 3 3 0 0 1 2 3v2a3 3 0 0 0 3 3M16 4a3 3 0 0 1 3 3v2a3 3 0 0 0 2 3 3 3 0 0 0-2 3v2a3 3 0 0 1-3 3"/></svg>`,
+  cone: `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><path d="M12 1.5v3.5M12 19v3.5M1.5 12h3.5M19 12h3.5"/></svg>`,
+  sort: `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m8 9 4-4 4 4M8 15l4 4 4-4"/></svg>`,
 };
 
 /* Shared topbar. `active` = nav item key. `variant`: "full" | "slim" */
@@ -491,4 +493,388 @@ function coordsCopyHTML(id = "coords-copy") {
     <span class="mono" style="font-weight:600">${coords}</span>
     <button class="icon-btn sm" id="${id}" title="Copy coordinates"
       onclick="copyText('${coords}', this)">${ICONS.copy}</button></span>`;
+}
+
+/* ==========================================================================
+   Cone search — shared across cone-1..4
+   ========================================================================== */
+
+/* ------------------------------------------------- coordinate conversion */
+
+const pad2 = (n) => String(n).padStart(2, "0");
+
+function degToHms(deg) {
+  let h = ((deg % 360) + 360) % 360 / 15;
+  const hh = Math.floor(h);
+  const remM = (h - hh) * 60;
+  const mm = Math.floor(remM);
+  const ss = (remM - mm) * 60;
+  return `${pad2(hh)}:${pad2(mm)}:${ss.toFixed(2).padStart(5, "0")}`;
+}
+
+function degToDms(deg) {
+  const sign = deg < 0 ? "-" : "+";
+  const a = Math.abs(deg);
+  const dd = Math.floor(a);
+  const remM = (a - dd) * 60;
+  const mm = Math.floor(remM);
+  const ss = (remM - mm) * 60;
+  return `${sign}${pad2(dd)}:${pad2(mm)}:${ss.toFixed(1).padStart(4, "0")}`;
+}
+
+function hmsToDeg(str) {
+  const p = String(str).trim().split(/[:\s]+/).map(Number);
+  if (p.some(Number.isNaN)) return NaN;
+  return ((p[0] || 0) + (p[1] || 0) / 60 + (p[2] || 0) / 3600) * 15;
+}
+
+function dmsToDeg(str) {
+  const s = String(str).trim();
+  const sign = s.startsWith("-") ? -1 : 1;
+  const p = s.replace(/^[+-]/, "").split(/[:\s]+/).map(Number);
+  if (p.some(Number.isNaN)) return NaN;
+  return sign * ((p[0] || 0) + (p[1] || 0) / 60 + (p[2] || 0) / 3600);
+}
+
+/* Accepts "315.4 68.16", "21:01:36.90 +68:09:48.0", either comma or space
+   separated. Returns {ra, dec} in degrees, or null when it can't be read.
+   This is what lets the single RA box absorb a pasted coordinate pair. */
+function parseCoordPair(text) {
+  const t = String(text).trim().replace(/,/g, " ").replace(/\s+/g, " ");
+  if (!t.includes(" ")) return null;
+  const sexa = t.match(/^([\d:.\s]+?)\s+([+-][\d:.\s]+)$/);
+  if (sexa && t.includes(":")) {
+    const ra = hmsToDeg(sexa[1]), dec = dmsToDeg(sexa[2]);
+    if (!Number.isNaN(ra) && !Number.isNaN(dec)) return { ra, dec };
+  }
+  const parts = t.split(" ");
+  if (parts.length === 2) {
+    const ra = Number(parts[0]), dec = Number(parts[1]);
+    if (!Number.isNaN(ra) && !Number.isNaN(dec)) return { ra, dec };
+  }
+  if (parts.length === 6) {
+    const ra = hmsToDeg(parts.slice(0, 3).join(":"));
+    const dec = dmsToDeg(parts.slice(3).join(":"));
+    if (!Number.isNaN(ra) && !Number.isNaN(dec)) return { ra, dec };
+  }
+  return null;
+}
+
+/* -------------------------------------------------------- cone sample data */
+
+const CONE_CENTER = { ra: 315.403750, dec: 68.163333, radius: 600 };
+
+/* Band -> validated FILTER_STYLE entry. Sparklines stay inside the four
+   already-validated hues rather than inventing new ones. */
+const BAND_STYLE = {
+  g: FILTER_STYLE["ZTF g"],
+  r: FILTER_STYLE["ZTF r"],
+  c: FILTER_STYLE["ATLAS c"],
+  o: FILTER_STYLE["ATLAS o"],
+};
+
+/* Display labels lifted from tarxiv/dashboard/components/cards.py SOURCE_LABELS
+   — note sherlock reaches us via Lasair, so the label credits both. */
+const SOURCE_LABELS = {
+  tns: "TNS", ztf: "ZTF", atlas: "ATLAS", asas_sn: "ASAS-SN",
+  sherlock: "Lasair-Sherlock", fink: "Fink", lasair: "Lasair", lsst: "LSST",
+};
+
+/* Tag colours are the real swatches from tarxiv/dashboard/styles.py */
+const CONE_TAGS = [
+  { name: "follow-up", color: "#b31b1b" },
+  { name: "host-z", color: "#2a78d6" },
+  { name: "young", color: "#199e70" },
+  { name: "spectrum needed", color: "#eda100" },
+  { name: "nuclear", color: "#4a3aa7" },
+  { name: "rising", color: "#eb6834" },
+];
+
+const TYPES = ["SN Ia", "SN II", "SN IIn", "SN Ib/c", "SLSN-I", "TDE", "AGN", null, null, null];
+const GROUPS = ["ZTF", "Pan-STARRS", "ATLAS", "ASAS-SN", "YSE", "WFST"];
+const HOSTS = [
+  "SDSS J210136.15+681108.3", "2MASXJ21013481+6809490", "NGC 7013",
+  "UGC 11635", "WISEA J210142.9+680921", null, null,
+];
+const LETTERS = "abcdefghijklmnopqrstuvwxyz";
+
+/* One transient's photometry: rise then decline, 1-3 bands, enough points to
+   read as a shape at 140x44. */
+function genConeLightcurve(rng, peak, nBands) {
+  const pool = ["g", "r", "o", "c"];
+  const bands = pool.slice(0, nBands);
+  const t0 = 40 + rng() * 30;
+  return bands.map((band, bi) => {
+    const off = bi * (0.15 + rng() * 0.3);
+    const pts = [];
+    const riseRate = 0.22 + rng() * 0.16;
+    const fallRate = 0.045 + rng() * 0.05;
+    for (let t = 0; t < 110; t += 3.5 + rng() * 3) {
+      const m = t < t0
+        ? peak + off + riseRate * (t0 - t)
+        : peak + off + fallRate * (t - t0);
+      if (m > peak + 3.6) continue;
+      pts.push([+t.toFixed(1), +(m + (rng() - 0.5) * 0.14).toFixed(3)]);
+    }
+    return { band, pts };
+  }).filter((s) => s.pts.length > 3);
+}
+
+function genConeResults(n = 24) {
+  const rng = mulberry32(21013690);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    /* separations spread across the cone, sorted ascending like the API's
+       ORDER BY distance_deg */
+    const sep = 11 + Math.pow(i / n, 1.35) * (CONE_CENTER.radius - 20) + rng() * 9;
+    const pa = rng() * 2 * Math.PI;
+    const dDec = (sep * Math.cos(pa)) / 3600;
+    const dRa = (sep * Math.sin(pa)) / 3600 / Math.cos((CONE_CENTER.dec * Math.PI) / 180);
+    const ra = CONE_CENTER.ra + dRa;
+    const dec = CONE_CENTER.dec + dDec;
+
+    const year = 2019 + Math.floor(rng() * 7);
+    const name = `${year}${LETTERS[Math.floor(rng() * 26)]}${LETTERS[Math.floor(rng() * 26)]}${LETTERS[Math.floor(rng() * 26)]}`;
+    const type = TYPES[Math.floor(rng() * TYPES.length)];
+    const peak = 17.2 + rng() * 3.2;
+    const nBands = 1 + Math.floor(rng() * 3);
+    const phot = genConeLightcurve(rng, peak, nBands);
+
+    const sources = ["tns"];
+    if (rng() > 0.25) sources.push("ztf");
+    if (rng() > 0.6) sources.push("atlas");
+    if (rng() > 0.7) sources.push("asas_sn");
+    if (rng() > 0.15) sources.push("sherlock");
+    if (rng() > 0.8) sources.push("fink");
+
+    const tags = [];
+    if (rng() > 0.55) tags.push(CONE_TAGS[Math.floor(rng() * CONE_TAGS.length)]);
+    if (rng() > 0.85) {
+      const t = CONE_TAGS[Math.floor(rng() * CONE_TAGS.length)];
+      if (!tags.includes(t)) tags.push(t);
+    }
+
+    const host = HOSTS[Math.floor(rng() * HOSTS.length)];
+    out.push({
+      obj_name: name,
+      ztf_id: sources.includes("ztf")
+        ? `ZTF${String(year).slice(2)}${Array.from({ length: 7 }, () => LETTERS[Math.floor(rng() * 26)]).join("")}`
+        : null,
+      tarxiv_id: `TXV-${year}-${String(Math.floor(rng() * 999999)).padStart(6, "0")}`,
+      ra: +ra.toFixed(6),
+      dec: +dec.toFixed(6),
+      ra_hms: degToHms(ra),
+      dec_dms: degToDms(dec),
+      sep_arcsec: +sep.toFixed(2),
+      object_type: type,
+      /* redshift only where there is a host to have measured it */
+      redshift: host && rng() > 0.3 ? +(0.02 + rng() * 0.4).toFixed(4) : null,
+      host,
+      host_sep_kpc: host ? +(1.2 + rng() * 17).toFixed(1) : null,
+      discovery_date: `${year}-${pad2(1 + Math.floor(rng() * 12))}-${pad2(1 + Math.floor(rng() * 28))}`,
+      reporting_group: GROUPS[Math.floor(rng() * GROUPS.length)],
+      peak_mag: +peak.toFixed(1),
+      peak_filter: phot.length ? phot[0].band : "g",
+      n_detections: 8 + Math.floor(rng() * 112),
+      sources,
+      tags,
+      phot,
+    });
+  }
+  return out.sort((a, b) => a.sep_arcsec - b.sep_arcsec);
+}
+
+const CONE_RESULTS = genConeResults(24);
+
+/* ---------------------------------------------------------- sparkline SVG */
+
+/* A thumbnail, not a plot: no axes, no grid, no markers, y inverted because
+   these are magnitudes. Identity is carried by the band chips rendered beside
+   it (see bandChipsHTML) so the colours are never the only cue. The readable
+   version of this data is the full lightcurve page one click away. */
+function sparklineSVG(phot, theme = currentTheme(), opts = {}) {
+  const w = opts.w || 140, h = opts.h || 44, pad = 3;
+  if (!phot || !phot.length) return `<svg width="${w}" height="${h}"></svg>`;
+
+  const all = phot.flatMap((s) => s.pts);
+  const xs = all.map((p) => p[0]), ys = all.map((p) => p[1]);
+  const x0 = Math.min(...xs), x1 = Math.max(...xs);
+  const y0 = Math.min(...ys), y1 = Math.max(...ys);
+  const sx = (x) => pad + ((x - x0) / (x1 - x0 || 1)) * (w - 2 * pad);
+  /* inverted: brighter (smaller magnitude) sits higher */
+  const sy = (y) => pad + ((y - y0) / (y1 - y0 || 1)) * (h - 2 * pad);
+
+  const paths = phot.map((s) => {
+    const d = s.pts.map((p, i) => `${i ? "L" : "M"}${sx(p[0]).toFixed(1)} ${sy(p[1]).toFixed(1)}`).join("");
+    const col = (BAND_STYLE[s.band] || BAND_STYLE.g)[theme];
+    return `<path d="${d}" fill="none" stroke="${col}" stroke-width="2"
+      stroke-linecap="round" stroke-linejoin="round"/>`;
+  }).join("");
+
+  const bands = phot.map((s) => s.band).join(", ");
+  return `<svg class="spark" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}"
+    role="img" aria-label="Lightcurve thumbnail, bands ${bands}"><title>Lightcurve (${bands})</title>${paths}</svg>`;
+}
+
+/* Band identity as text + colour, so the sparkline is never colour-alone. */
+function bandChipsHTML(phot) {
+  return (phot || []).map((s) => {
+    const col = (BAND_STYLE[s.band] || BAND_STYLE.g)[currentTheme()];
+    return `<span class="band-chip"><i style="background:${col}"></i>${s.band}</span>`;
+  }).join("");
+}
+
+/* ------------------------------------------------------- result fragments */
+
+const EM_DASH = "—";
+const fmtType = (t) => t
+  ? `<span class="chip brand type-chip">${t}</span>`
+  : `<span class="chip type-chip faint">unclassified</span>`;
+const fmtZ = (z) => (z == null ? EM_DASH : z.toFixed(4));
+/* always one decimal, so a column of magnitudes stays aligned */
+const fmtMag = (m) => (m == null ? EM_DASH : m.toFixed(1));
+const fmtSep = (s) => (s < 60 ? `${s.toFixed(1)}″` : `${(s / 60).toFixed(1)}′`);
+
+function coneTagsHTML(tags) {
+  return (tags || []).map((t) =>
+    `<span class="chip tag-chip" style="background:${t.color}1a;color:${t.color};border-color:${t.color}40">${t.name}</span>`
+  ).join("");
+}
+
+function coneSourcesHTML(sources) {
+  return (sources || []).map((s) =>
+    `<span class="src-pill">${SOURCE_LABELS[s] || s}</span>`).join("");
+}
+
+function coneNameHTML(o) {
+  return `<a class="obj-name" href="mockup-2-balanced.html">${o.obj_name}</a>` +
+    (o.ztf_id ? `<span class="alias mono">${o.ztf_id}</span>` : "");
+}
+
+/* --------------------------------------------------------- the search bar */
+
+/* One compressed bar, identical in all four mockups — the options differ in
+   how results are presented, not how the search is entered. */
+function coneSearchBarHTML() {
+  return `
+  <div class="cone-bar-top">
+    <span class="cone-bar-title">${ICONS.cone} Cone search</span>
+    <div class="spacer"></div>
+    <div class="seg" id="cone-fmt">
+      <button class="active" data-fmt="deg">deg</button>
+      <button data-fmt="sex">hms:dms</button>
+    </div>
+  </div>
+  <div class="cone-bar-fields">
+    <label class="cone-field ra"><span class="lab">RA</span>
+      <input id="cone-ra" class="mono" spellcheck="false"></label>
+    <label class="cone-field dec"><span class="lab">Dec</span>
+      <input id="cone-dec" class="mono" spellcheck="false"></label>
+    <label class="cone-field rad"><span class="lab">Radius</span>
+      <input id="cone-radius" class="mono" spellcheck="false"><i class="unit">″</i></label>
+    <button class="btn btn-primary">${ICONS.search} Search</button>
+    <div class="spacer"></div>
+    <span class="cone-hint faint small">Paste <span class="mono">21:01:36.90 +68:09:48.0</span> into RA to fill both</span>
+  </div>`;
+}
+
+function mountConeSearchBar(el, opts = {}) {
+  el.classList.add("cone-bar", "card");
+  el.innerHTML = coneSearchBarHTML();
+
+  const raEl = el.querySelector("#cone-ra");
+  const decEl = el.querySelector("#cone-dec");
+  const radEl = el.querySelector("#cone-radius");
+  const state = { ra: CONE_CENTER.ra, dec: CONE_CENTER.dec, fmt: "deg" };
+  radEl.value = String(opts.radius ?? CONE_CENTER.radius);
+
+  const paint = () => {
+    if (state.fmt === "deg") {
+      raEl.value = state.ra.toFixed(6);
+      decEl.value = state.dec.toFixed(6);
+    } else {
+      raEl.value = degToHms(state.ra);
+      decEl.value = degToDms(state.dec);
+    }
+  };
+
+  /* read the boxes back in whichever format is showing */
+  const readBack = () => {
+    if (state.fmt === "deg") {
+      const ra = Number(raEl.value), dec = Number(decEl.value);
+      if (!Number.isNaN(ra)) state.ra = ra;
+      if (!Number.isNaN(dec)) state.dec = dec;
+    } else {
+      const ra = hmsToDeg(raEl.value), dec = dmsToDeg(decEl.value);
+      if (!Number.isNaN(ra)) state.ra = ra;
+      if (!Number.isNaN(dec)) state.dec = dec;
+    }
+  };
+
+  el.querySelectorAll("#cone-fmt button").forEach((b) => {
+    b.onclick = () => {
+      readBack();
+      state.fmt = b.dataset.fmt;
+      el.querySelectorAll("#cone-fmt button").forEach((x) => x.classList.toggle("active", x === b));
+      paint();
+    };
+  });
+
+  /* a pasted "RA Dec" pair splits itself across both boxes */
+  const absorbPair = () => {
+    const pair = parseCoordPair(raEl.value);
+    if (!pair) return;
+    state.ra = pair.ra; state.dec = pair.dec;
+    state.fmt = raEl.value.includes(":") ? "sex" : "deg";
+    el.querySelectorAll("#cone-fmt button").forEach((x) =>
+      x.classList.toggle("active", x.dataset.fmt === state.fmt));
+    paint();
+  };
+  raEl.addEventListener("paste", () => setTimeout(absorbPair, 0));
+  raEl.addEventListener("change", absorbPair);
+  decEl.addEventListener("change", readBack);
+
+  paint();
+  return state;
+}
+
+function coneSummaryHTML(results, radius = CONE_CENTER.radius) {
+  return `<b>${results.length}</b> objects within ${radius}″ of
+    <span class="mono">${CONE_CENTER.ra.toFixed(6)} ${CONE_CENTER.dec >= 0 ? "+" : ""}${CONE_CENTER.dec.toFixed(6)}</span>`;
+}
+
+/* --------------------------------------------------------- cone sky view */
+
+function mountConeAladin(el, results = CONE_RESULTS, opts = {}) {
+  const fallback = () => {
+    el.innerHTML = `<div class="aladin-fallback">
+      <strong>Aladin Lite unavailable</strong>
+      <span>CDN script did not load — sky view shows here<br>
+      (PanSTARRS DR1 colour, ${results.length} objects within ${CONE_CENTER.radius}″)</span></div>`;
+  };
+  if (typeof A === "undefined") { fallback(); return null; }
+  let aladin = null;
+  A.init.then(() => {
+    aladin = A.aladin(el, {
+      survey: "P/PanSTARRS/DR1/color-z-zg-g",
+      target: `${CONE_CENTER.ra} ${CONE_CENTER.dec}`,
+      fov: opts.fov || (CONE_CENTER.radius / 3600) * 2.6,
+      showFullscreenControl: true,
+      showLayersControl: false,
+      showFrame: false,
+      showCooGridControl: false,
+      reticleColor: "#e34948",
+      reticleSize: 22,
+    });
+    /* the search radius, drawn as a ring */
+    const overlay = A.graphicOverlay({ color: "#e34948", lineWidth: 1.4 });
+    aladin.addOverlay(overlay);
+    overlay.add(A.circle(CONE_CENTER.ra, CONE_CENTER.dec, CONE_CENTER.radius / 3600, {
+      color: "#e34948", lineWidth: 1.4,
+    }));
+    const cat = A.catalog({ shape: "circle", color: "#e34948", sourceSize: 12 });
+    aladin.addCatalog(cat);
+    cat.addSources(results.map((o) => A.source(o.ra, o.dec, { name: o.obj_name })));
+  }).catch(fallback);
+  return () => aladin;
 }

--- a/setup/.env.sample
+++ b/setup/.env.sample
@@ -44,6 +44,10 @@ TARXIV_IMAP_USERNAME="service@example.com"
 TARXIV_IMAP_PASSWORD=""
 # TARXIV Host Log Directory
 TARXIV_HOST_LOG_DIR="./.data/logs/"
+# Shared default reporting mode for API/ingest entrypoints.
+# Bitmask: 1=PRINT, 2=LOGFILE, 4=DATABASE.
+# Dev default is 3 (PRINT|LOGFILE), prod-like is 7.
+TARXIV_REPORTING_MODE="7"
 # TARXIV Image Source (local or ghcr.io)
 TARXIV_IMAGE_SOURCE="local"
 TARXIV_IMAGE_TAG="latest"

--- a/setup/.env.sample
+++ b/setup/.env.sample
@@ -1,3 +1,9 @@
+# Compose profiles enabled by default for every `docker compose` invocation in
+# this directory. Uncomment and edit to pin your usual dev set; without it a
+# bare `docker compose up` starts only elasticsearch, couchbase, postgres and
+# redis. Available: tarxiv, tools, logging, kafka, monitoring, proxy.
+COMPOSE_PROFILES=tarxiv,tools
+
 # Token read-only for testing purposes
 ATLASAPI_CONFIG=""
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -3,14 +3,33 @@
 This directory contains the Docker configurations for the services required by the TarXiv pipeline and API. To start-up the services, run the following commands:
 
 ```commandline
-docker compose run setup_elasticsearch
-docker compose up elasticsearch logstash kibana couchbase postgres
-docker compose run --rm tarxiv-migrate
+docker compose run setup_elasticsearch     # one-shot Elasticsearch bootstrap
+docker compose up -d                       # couchbase, postgres, redis
+docker compose run --rm tarxiv-migrate     # apply Alembic migrations
+docker compose --profile tarxiv up -d      # the API and dashboard
 ```
 
 The second command will take about one minute to correctly start-up the Couchbase daemon.
 
 ###### You can access the Couchbase web interface at http://localhost:8091/.
+
+## Service profiles
+
+A bare `docker compose up` starts only the four backing stores needed by the dev loop. Everything else is opt-in via a profile:
+
+| Profile | Services | Start with |
+|---|---|---|
+| *(default)* | couchbase, postgres, redis | `docker compose up -d` |
+| `tarxiv` | tarxiv-migrate, tarxiv-api, tarxiv-dashboard | `docker compose --profile tarxiv up -d` |
+| `tools` | adminer (DB browser on :8079) | `docker compose --profile tools up -d` |
+| `logging` | elasticsearch, logstash, kibana | `docker compose --profile logging up -d` |
+| `kafka` | kafka-broker, schema registry, connect, rest proxy, kafbat-ui, prometheus | `docker compose --profile kafka up -d` |
+| `monitoring` | prometheus | `docker compose --profile monitoring up -d` |
+| `proxy` | nginx-proxy, nginx-letsencrypt (deployment only) | `docker compose --profile proxy up -d` |
+| `setup_elasticsearch` | one-shot Elasticsearch bootstrap | `docker compose run setup_elasticsearch` |
+
+Naming a service on the command line auto-enables its profile, so `docker compose up -d tarxiv-api` works without `--profile tarxiv`. Profiles can be combined (`--profile kafka --profile logging`), and if you always want the same set you can pin it once in `.env` with `COMPOSE_PROFILES=tarxiv,tools`.
+
 
 # Local development setup
 

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -244,6 +244,7 @@ services:
       - ../docs:/app/docs:Z
       - ../tarxiv:/app/tarxiv:Z
       - ../aux/config.yml:/app/aux/config.yml:Z
+      - ../aux/citations:/app/aux/citations:Z
       - ../examples:/app/examples:Z
       - ../scripts:/app/scripts:Z
       - ${TARXIV_HOST_LOG_DIR:-.data/logs}:/data/tarxiv/logs:rw,z
@@ -289,6 +290,7 @@ services:
       - ../bin:/app/bin:Z
       - ../tarxiv:/app/tarxiv:Z
       - ../aux/config.yml:/app/aux/config.yml:Z
+      - ../aux/citations:/app/aux/citations:Z
       - ../examples:/app/examples:Z
       - ../scripts:/app/scripts:Z
       - ${TARXIV_HOST_LOG_DIR:-.data/logs}:/data/tarxiv/logs:rw,z

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -1,3 +1,18 @@
+# Service profiles. A bare `docker compose up` starts only the backing stores
+# needed by the local dev loop (couchbase, postgres, redis);
+# everything else is opt-in via a profile:
+#
+#   logging              logstash, kibana, elasticsearch
+#   kafka                kafka-broker, kafka-schema-registry, kafka-connect,
+#                        kafka-rest-proxy, kafbat-ui, prometheus
+#   monitoring           prometheus
+#   tools                adminer
+#   tarxiv               tarxiv-migrate, tarxiv-api, tarxiv-dashboard
+#   proxy                nginx-proxy, nginx-letsencrypt
+#   setup_elasticsearch  setup_elasticsearch (one-shot bootstrap)
+#
+# Naming a service on the command line auto-enables its profile, so
+# `docker compose up -d tarxiv-api` works without `--profile tarxiv`.
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:1.6
@@ -61,6 +76,8 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
+    profiles:
+      - logging
     volumes:
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,Z
       - ${TARXIV_ELASTIC_DATA_DIR}:/usr/share/elasticsearch/data:Z
@@ -78,6 +95,8 @@ services:
 
   logstash:
     image: docker.elastic.co/logstash/logstash:9.0.2
+    profiles:
+      - logging
     volumes:
       - ./logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
       - ./tarxiv_logstash.conf:/usr/share/logstash/pipeline/tarxiv_logstash.conf:ro,Z
@@ -100,6 +119,8 @@ services:
 
   kibana:
     image: docker.elastic.co/kibana/kibana:9.0.2
+    profiles:
+      - logging
     volumes:
       - ./kibana.yml:/usr/share/kibana/config/kibana.yml:ro,Z
     ports:
@@ -141,7 +162,9 @@ services:
     ports:
       - 6379:6379
     environment:
-      - REDIS_PASSWORD:${TARXIV_REDIS_PASSWORD}
+      # Inert either way: the official redis image ignores REDIS_PASSWORD and
+      # needs `--requirepass`. Kept in mapping form to match the other services.
+      REDIS_PASSWORD: ${TARXIV_REDIS_PASSWORD}
     networks:
       - tarxiv_net
 
@@ -167,6 +190,8 @@ services:
 
   adminer:
     image: adminer:latest
+    profiles:
+      - tools
     ports:
       - 8079:8080
     networks:
@@ -295,6 +320,8 @@ services:
   
   kafka-broker:
     image: confluentinc/cp-kafka:8.0.0
+    profiles:
+      - kafka
     hostname: kafka-broker
     container_name: kafka-broker
     ports:
@@ -323,6 +350,8 @@ services:
 
   kafka-schema-registry:
     image: confluentinc/cp-schema-registry:8.0.0
+    profiles:
+      - kafka
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -338,6 +367,8 @@ services:
 
   kafka-connect:
     image: cnfldemos/kafka-connect-datagen:0.6.4-7.6.0
+    profiles:
+      - kafka
     hostname: connect
     container_name: connect
     depends_on:
@@ -365,6 +396,8 @@ services:
 
   kafka-rest-proxy:
     image: confluentinc/cp-kafka-rest:8.0.0
+    profiles:
+      - kafka
     depends_on:
       - kafka-broker
       - kafka-schema-registry
@@ -384,6 +417,8 @@ services:
   kafbat-ui:
     container_name: kafbat-ui
     image: ghcr.io/kafbat/kafka-ui:latest
+    profiles:
+      - kafka
     ports:
       - 8080:8080
     networks:
@@ -406,6 +441,9 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
+    # In the kafka profile, kafbat uses it. 
+    profiles:
+      - kafka
     hostname: prometheus
     container_name: prometheus
     ports:
@@ -421,7 +459,6 @@ networks:
     driver: bridge
 
 volumes:
-  elasticsearch:
   nginx_certs:
   nginx_vhost:
   nginx_html:

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -5,7 +5,6 @@
 #   logging              logstash, kibana, elasticsearch
 #   kafka                kafka-broker, kafka-schema-registry, kafka-connect,
 #                        kafka-rest-proxy, kafbat-ui, prometheus
-#   monitoring           prometheus
 #   tools                adminer
 #   tarxiv               tarxiv-migrate, tarxiv-api, tarxiv-dashboard
 #   proxy                nginx-proxy, nginx-letsencrypt
@@ -56,6 +55,7 @@ services:
   setup_elasticsearch:
     profiles:
       - setup_elasticsearch
+      - logging
     image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
     init: true
     entrypoint: /entrypoint.sh

--- a/tarxiv/alerts.py
+++ b/tarxiv/alerts.py
@@ -175,7 +175,9 @@ class IMAP(TarxivModule):
                     self.logger.info(status, extra=status)
                     # Now submit what we have
                     for tns_obj_id in alerts:
-                        self.producer.produce(topic="tns_alerts", value=tns_obj_id, callback=self.acked)
+                        self.producer.produce(
+                            topic="tns_alerts", value=tns_obj_id, callback=self.acked
+                        )
                     # Mark read, when submitted all alerts
                     self.mark_read(uid)
 

--- a/tarxiv/api.py
+++ b/tarxiv/api.py
@@ -590,8 +590,6 @@ class API(TarxivModule):
                 "source_id": source_id,
             }
             try:
-                # Require a valid token (raises PermissionError -> 401 below).
-                self._require_authenticated_user_id(token)
                 # Find object info
                 tarxiv_id = self.txv_db.get_source_txv_id(source_id)
                 result = self.txv_db.get(tarxiv_id, scope="objects", collection="meta")
@@ -712,47 +710,15 @@ class API(TarxivModule):
                 "token": token,
                 "n_rows": request_json.get("n_rows"),
                 "offset": request_json.get("offset"),
-                "tag_ids": request_json.get("tag_ids", []),
             }
             try:
-                # Return error if bad token
-                validation = self.validate_token_request(token)
-                if not validation["is_valid"]:
-                    if validation["status"] == "expired":
-                        raise PermissionError("Session expired — please log in again.")
-                    else:
-                        raise PermissionError("Invalid or missing token.")
+                # No token required: alerts are public. The paging check below is
+                # the only guard on the values interpolated into the query, so it
+                # must stay ahead of it.
                 if not isinstance(request_json.get("n_rows"), int) or not isinstance(
                     request_json.get("offset"), int
                 ):
                     raise ValueError("n_rows/offset must be an integer")
-                if not isinstance(request_json.get("tag_ids", []), list):
-                    raise ValueError("tag_ids must be a list")
-
-                user_id = self._require_authenticated_user_id(token)
-                tag_ids = request_json.get("tag_ids", [])
-                tagged_object_ids: list[str] | None = None
-                if tag_ids:
-                    tagged_object_ids = self.user_db.list_tagged_object_ids_for_user(
-                        user_id, tag_ids
-                    )
-                    if not tagged_object_ids:
-                        result = []
-                        status_code = 200
-                        log["status"] = "Success"
-                        self.logger.info(log, extra=log)
-                        return server_response(result, status_code)
-
-                # object_filter = ""
-                # if tagged_object_ids is not None:
-                #     escaped_ids = [
-                #         object_id.replace("\\", "\\\\").replace('"', '\\"')
-                #         for object_id in tagged_object_ids
-                #     ]
-                #     object_list = ", ".join(
-                #         f'"{object_id}"' for object_id in escaped_ids
-                #     )
-                #     object_filter = f" AND META().id IN [{object_list}]"
 
                 # Per-source TNS fields now live under data_sources.tns; the
                 # object's canonical coordinates/provenance live at the top
@@ -775,10 +741,11 @@ class API(TarxivModule):
                 # Normal return
                 status_code = 200
                 log["status"] = "Success"
-            except PermissionError as e:
-                result = {"error": str(e), "type": "token"}
-                status_code = 401
-                log["status"] = "PermissionError"
+            except ValueError as e:
+                # Public endpoint: malformed paging is a client error, not a 500.
+                result = {"error": str(e), "type": "validation"}
+                status_code = 400
+                log["status"] = "ValueError"
             except LookupError as e:
                 result = {"error": str(e), "type": "lookup"}
                 status_code = 404
@@ -806,10 +773,6 @@ class API(TarxivModule):
                 "search": search,
             }
             try:
-                # Return error if bad token
-                validation = self.validate_token_request(token)
-                if not validation["is_valid"]:
-                    raise PermissionError("bad token")
                 # Build query
                 query_str = "SELECT object_id FROM tarxiv.tns.objects objWHERE 1=1 AND "
                 # Add restrictions from search fields, then append search params to query

--- a/tarxiv/dashboard/app.py
+++ b/tarxiv/dashboard/app.py
@@ -46,6 +46,14 @@ class TarxivDashboard(TarxivModule):
                 "https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js",
                 # "//aladin.u-strasbg.fr/AladinLite/api/v3/3.2.0/aladin.js",
             ],
+            external_stylesheets=[
+                # UI + monospace faces referenced by the Mantine theme
+                # (theme_manager.FONT_STACK / MONO_STACK). Both fall back to
+                # system fonts if the CDN is unreachable.
+                "https://fonts.googleapis.com/css2"
+                "?family=Inter:wght@400;500;600;700"
+                "&family=JetBrains+Mono:wght@400;600&display=swap",
+            ],
         )
 
         # Attach the class instances to the underlying Flask server.

--- a/tarxiv/dashboard/assets/lightcurve_aladin.js
+++ b/tarxiv/dashboard/assets/lightcurve_aladin.js
@@ -1,0 +1,79 @@
+/* Clientside callback for the object-page Aladin Lite widget.
+ *
+ * Registers `window.dash_clientside.lightcurve_aladin.initialize`, wired up
+ * from tarxiv/dashboard/pages/lightcurve.py via ClientsideFunction. Doing it
+ * this way (assets file + explicit namespace) avoids the
+ * `dc[namespace][function_name] is undefined` errors that can occur with
+ * complex inline-string clientside callbacks under Dash 4, and matches
+ * cone_aladin.js.
+ *
+ * Centres the sky view on the object and marks its position. The page is
+ * server-rendered, so this polls for the container rather than watching the
+ * whole document for Plotly to appear (which the previous inline version did,
+ * and which broke whenever the DOM order changed).
+ */
+window.dash_clientside = window.dash_clientside || {};
+window.dash_clientside.lightcurve_aladin = {
+    initialize: function (storeData) {
+        if (
+            !storeData ||
+            storeData.ra_deg === null ||
+            storeData.ra_deg === undefined ||
+            storeData.dec_deg === null ||
+            storeData.dec_deg === undefined
+        ) {
+            return "No coordinates available for Aladin";
+        }
+
+        const ra = storeData.ra_deg;
+        const dec = storeData.dec_deg;
+        // Wide enough to show the host galaxy context, tight enough to place
+        // the transient within it.
+        const fov = 0.1;
+
+        let attempts = 0;
+
+        function initAladin() {
+            const container = document.getElementById("aladin-lite-div");
+            if (!container || !window.A) {
+                // Give up after ~10s rather than polling forever.
+                if (attempts++ > 100) {
+                    console.warn("Aladin Lite did not become available");
+                    return;
+                }
+                setTimeout(initAladin, 100);
+                return;
+            }
+
+            window.A.init.then(function () {
+                container.innerHTML = "";
+                const aladin = window.A.aladin("#aladin-lite-div", {
+                    survey: "P/PanSTARRS/DR1/color-z-zg-g",
+                    target: ra + " " + dec,
+                    fov: fov,
+                    showFullscreenControl: true,
+                    showLayersControl: false,
+                    showFrame: false,
+                    reticleColor: "#e34948",
+                });
+
+                try {
+                    const catalog = window.A.catalog({
+                        shape: "circle",
+                        color: "#e34948",
+                        sourceSize: 16,
+                    });
+                    aladin.addCatalog(catalog);
+                    catalog.addSources([
+                        window.A.source(ra, dec, { name: storeData.source || "object" }),
+                    ]);
+                } catch (err) {
+                    console.warn("Aladin marker overlay failed:", err);
+                }
+            });
+        }
+
+        initAladin();
+        return "Aladin initialised";
+    },
+};

--- a/tarxiv/dashboard/assets/object_page.js
+++ b/tarxiv/dashboard/assets/object_page.js
@@ -1,0 +1,47 @@
+/* Clientside helpers for the object (lightcurve) page.
+ *
+ * Registers `window.dash_clientside.object_page`, wired up from
+ * tarxiv/dashboard/pages/lightcurve.py via ClientsideFunction. The assets file
+ * + explicit namespace form is used throughout this app because complex
+ * inline-string clientside callbacks are unreliable under Dash 4 (see the
+ * comments in lightcurve_aladin.js / cone_aladin.js).
+ */
+window.dash_clientside = window.dash_clientside || {};
+window.dash_clientside.object_page = {
+    /* Bring the tag card into view from the "Tag" button in the page head.
+     * The tag card is the single place tags are managed, so rather than
+     * duplicating the assign controls up top we jump to them and put the
+     * cursor in the select. */
+    scrollToTags: function (nClicks) {
+        if (!nClicks) {
+            return window.dash_clientside.no_update;
+        }
+
+        const card = document.getElementById("object-tag-card");
+        if (!card) {
+            return window.dash_clientside.no_update;
+        }
+
+        card.scrollIntoView({ behavior: "smooth", block: "center" });
+
+        // Brief ring so it is obvious where the page landed.
+        const previousTransition = card.style.transition;
+        card.style.transition = "box-shadow 200ms ease";
+        card.style.boxShadow = "0 0 0 2px var(--tarxiv-primary-ink)";
+        setTimeout(function () {
+            card.style.boxShadow = "";
+            card.style.transition = previousTransition;
+        }, 1200);
+
+        // Focus the tag select once the scroll has settled, so the button
+        // leaves the user ready to type.
+        setTimeout(function () {
+            const select = document.getElementById("assign-object-tag-select");
+            if (select) {
+                select.focus();
+            }
+        }, 400);
+
+        return window.dash_clientside.no_update;
+    },
+};

--- a/tarxiv/dashboard/callbacks/style_callbacks.py
+++ b/tarxiv/dashboard/callbacks/style_callbacks.py
@@ -6,10 +6,13 @@ from dash import (
     ALL,
     clientside_callback,
     ctx,
+    dcc,
+    no_update,
     page_registry,
 )
+import dash_mantine_components as dmc
 import plotly.io as pio
-from ..components import create_nav_link
+from dash_iconify import DashIconify
 
 
 def register_style_callbacks(app, logger):
@@ -86,22 +89,63 @@ def register_style_callbacks(app, logger):
         return [theme_patch] * len(plot_outputs), theme_icon
 
     @app.callback(
-        Output("nav-rail-content", "children"),
+        [
+            Output("topbar-nav", "children"),
+            Output("mobile-nav-content", "children"),
+        ],
         Input("url", "pathname"),  # Requires dcc.Location(id="url") in the layout
     )
     def refresh_navigation(pathname):
-        # # Sort pages by the 'order' key you added in dash.register_page
+        # Sort pages by the 'order' key set in dash.register_page
         pages = page_registry.values()
         nav_pages = [p for p in pages if p.get("order") is not None]
         nav_pages = sorted(nav_pages, key=lambda x: x["order"])
 
-        return [
-            create_nav_link(
-                icon=page.get("icon", "mdi:help-circle"),
-                label=page["name"],
-                # label=page["title"],
+        topbar_links = [
+            dcc.Link(
+                page["name"],
                 href=page["relative_path"],
-                is_active=(pathname == page["relative_path"]),
+                className="tarxiv-topnav-link"
+                + (" active" if pathname == page["relative_path"] else ""),
             )
             for page in nav_pages
         ]
+        mobile_links = [
+            dmc.NavLink(
+                label=page["name"],
+                href=page["relative_path"],
+                leftSection=DashIconify(
+                    icon=page.get("icon", "mdi:help-circle"), width=20
+                ),
+                active=(pathname == page["relative_path"]),
+            )
+            for page in nav_pages
+        ]
+
+        return (
+            dmc.Group(topbar_links, gap=2, wrap="nowrap"),
+            mobile_links,
+        )
+
+    # --- Global object search (topbar, present on every page) ---
+    @app.callback(
+        Output("url", "pathname", allow_duplicate=True),
+        Input("global-search-keyboard", "n_keydowns"),
+        State("global-search-input", "value"),
+        prevent_initial_call=True,
+    )
+    def global_search(n_keydowns, object_id):
+        if not object_id or not object_id.strip():
+            return no_update
+        return f"/lightcurve/{object_id.strip()}"
+
+    # --- Mobile navigation drawer ---
+    @app.callback(
+        Output("app-shell", "navbar"),
+        Input("burger", "opened"),
+        prevent_initial_call=True,
+    )
+    def toggle_mobile_nav(opened):
+        navbar = Patch()
+        navbar["collapsed"]["mobile"] = not opened
+        return navbar

--- a/tarxiv/dashboard/components/__init__.py
+++ b/tarxiv/dashboard/components/__init__.py
@@ -16,11 +16,13 @@ from .cards import (
     title_card,
     footer_card,
     create_message_banner,
+    tag_badge,
 )
 from .object_view import (
     build_empty_search_state,
     build_key_facts,
     build_photometry_table,
+    build_tag_chips,
 )
 from .theme_manager import (
     apply_theme,
@@ -45,9 +47,11 @@ __all__ = [
     "title_card",
     "footer_card",
     "create_message_banner",
+    "tag_badge",
     "build_empty_search_state",
     "build_key_facts",
     "build_photometry_table",
+    "build_tag_chips",
     "apply_theme",
     "get_theme",
     "register_tarxiv_templates",

--- a/tarxiv/dashboard/components/__init__.py
+++ b/tarxiv/dashboard/components/__init__.py
@@ -15,15 +15,18 @@ from .cards import (
     expressive_card,
     title_card,
     footer_card,
-    create_nav_item,
-    create_nav_link,
     create_message_banner,
 )
+from .object_view import (
+    build_empty_search_state,
+    build_key_facts,
+    build_photometry_table,
+)
 from .theme_manager import (
-    get_theme_components,
     apply_theme,
-    get_filter_style,
+    get_theme,
     register_tarxiv_templates,
+    scheme_from_template,
 )
 from .cookies import (
     get_cookie_popup,
@@ -41,13 +44,14 @@ __all__ = [
     "expressive_card",
     "title_card",
     "footer_card",
-    "create_nav_item",
-    "create_nav_link",
     "create_message_banner",
-    "get_theme_components",
+    "build_empty_search_state",
+    "build_key_facts",
+    "build_photometry_table",
     "apply_theme",
-    "get_filter_style",
+    "get_theme",
     "register_tarxiv_templates",
+    "scheme_from_template",
     "get_cookie_popup",
     "COOKIE_DEFAULTS",
 ]

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -236,7 +236,9 @@ SOURCE_LABELS = {
     "asas_sn": "ASAS-SN",
     "asas-sn": "ASAS-SN",
     "asas-sn_skypatrol": "ASAS-SN Skypatrol",
-    "sherlock": "Sherlock",
+    # Sherlock results reach us through Lasair (see pipeline.py), so the label
+    # credits both. The stored key stays "sherlock".
+    "sherlock": "Lasair-Sherlock",
     "fink": "Fink",
     "mangrove": "Mangrove",
     "lasair": "Lasair",

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -85,6 +85,7 @@ def expressive_card(
     children,
     title=None,
     title_order: Literal[1, 2, 3, 4, 5, 6] = 2,
+    icon: str | None = None,
     header_extra=None,
     body_padding: str | int = "md",
     **kwargs,
@@ -92,13 +93,15 @@ def expressive_card(
     """Create the standard surface card.
 
     A bordered, softly shadowed 14px-radius card. When a title is given it sits
-    in a divider-separated header row, optionally alongside ``header_extra``
-    (a control such as a toggle or copy button) pinned to the right.
+    in a divider-separated header row, preceded by an optional ``icon`` and
+    optionally alongside ``header_extra`` (a control such as a toggle or copy
+    button) pinned to the right.
 
     Args:
         children: List of child components
         title: Optional title for the card header
         title_order: Heading order (1-6)
+        icon: Optional Iconify name shown before the title
         header_extra: Optional component placed at the right of the header
         body_padding: Padding for the card body (0 lets a child bleed to the edge)
         **kwargs: Additional keyword arguments for dmc.Paper
@@ -112,7 +115,12 @@ def expressive_card(
 
     card_children = []
     if title:
-        header = [
+        header = []
+        if icon:
+            header.append(
+                DashIconify(icon=icon, width=15, style={"color": "var(--tarxiv-ink-3)"})
+            )
+        header += [
             dmc.Title(title, order=title_order, fz=13, fw=600),
             dmc.Box(style={"flex": 1}),
         ]
@@ -138,6 +146,36 @@ def expressive_card(
         p=0,
         radius=14,
         style=style,
+        **kwargs,
+    )
+
+
+def tag_badge(tag: dict, size: str = "sm", **kwargs):
+    """Render a tag as a coloured badge.
+
+    Tag colours are stored as CSS hex strings (``#4287f5``). They are passed to
+    Mantine verbatim: stripping the ``#`` -- as this code used to -- turns the
+    value into ``4287f5``, which Mantine reads as a *named* palette key, fails
+    to resolve, and so renders every custom tag in the fallback colour.
+
+    Args:
+        tag: A tag dict with at least ``name``; ``color`` is optional
+        size: Mantine badge size
+        **kwargs: Additional keyword arguments for dmc.Badge
+
+    Returns
+    -------
+        dmc.Badge coloured by the tag
+    """
+    return dmc.Badge(
+        tag.get("name", "unnamed"),
+        color=tag.get("color") or "gray",
+        variant="light",
+        size=size,
+        radius="sm",
+        # Mantine upper-cases badges by default; tag names are user-authored
+        # and read better as written.
+        tt="none",
         **kwargs,
     )
 
@@ -476,7 +514,7 @@ def _build_citation_component(citation_str: str | None):
 
 
 def format_object_metadata(
-    object_id, meta, citation_str=None, lc_data=None, logger=None
+    object_id, meta, citation_str=None, lc_data=None, assigned_tags=None, logger=None
 ):
     """Format object metadata for display.
 
@@ -489,6 +527,7 @@ def format_object_metadata(
         meta: Metadata dictionary (source-keyed schema, see MetadataResponseModel)
         citation_str: Optional concatenated BibTeX citation string
         lc_data: Optional photometry list, used for the detection-count fact
+        assigned_tags: Optional tag assignments, shown as chips in the page head
         logger: Optional logger instance
 
     Returns
@@ -510,6 +549,7 @@ def format_object_metadata(
     lightcurve_card = expressive_card(
         children=build_lightcurve_body(),
         title="Lightcurve",
+        icon="clarity:curve-chart-line",
         header_extra=build_view_toggle(),
         body_padding="xs",
     )
@@ -523,13 +563,19 @@ def format_object_metadata(
             ),
         ],
         title="Sky view",
+        icon="mdi:earth",
         header_extra=dmc.Text("PanSTARRS DR1", size="xs", c="dimmed", ff="monospace"),
         body_padding=0,
     )
 
     results_top = dmc.Stack(
         [
-            build_page_head(object_id, meta, _build_coordinates_header(meta)),
+            build_page_head(
+                object_id,
+                meta,
+                _build_coordinates_header(meta),
+                assigned_tags=assigned_tags,
+            ),
             build_summary_strip(build_key_facts(meta, lc_data)),
             build_hero_grid(object_id, lightcurve_card, sky_card),
         ],
@@ -546,6 +592,7 @@ def format_object_metadata(
             offsetScrollbars=True,
         ),
         title="Source metadata",
+        icon="mdi:table",
         header_extra=dmc.Text(
             " · ".join(_source_label(key) for key in _ordered_sources(data_sources))
             or "no sources",
@@ -558,6 +605,7 @@ def format_object_metadata(
     citations_card = expressive_card(
         children=citations_component,
         title="Citations",
+        icon="mdi:format-quote-close",
     )
 
     # Full metadata JSON — collapsible, collapsed by default, at the very bottom.
@@ -568,7 +616,22 @@ def format_object_metadata(
             dmc.AccordionItem(
                 value="full-metadata",
                 children=[
-                    dmc.AccordionControl("Full Metadata (JSON)"),
+                    dmc.AccordionControl(
+                        # Icon inline with the label; the control's own `icon`
+                        # prop renders it at the far end of the row.
+                        dmc.Group(
+                            [
+                                DashIconify(
+                                    icon="mdi:code-json",
+                                    width=15,
+                                    style={"color": "var(--tarxiv-ink-3)"},
+                                ),
+                                dmc.Text("Full Metadata (JSON)", size="sm", fw=500),
+                            ],
+                            gap=10,
+                            wrap="nowrap",
+                        )
+                    ),
                     dmc.AccordionPanel(
                         dmc.Code(
                             json.dumps(meta, indent=2),

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -9,49 +9,46 @@ from dash import dcc, html
 from dash_iconify import DashIconify
 
 from ..styles import CARD_STYLE
+from .object_view import (
+    build_hero_grid,
+    build_key_facts,
+    build_lightcurve_body,
+    build_page_head,
+    build_summary_strip,
+    build_view_toggle,
+)
+from .plots import PLOT_HEIGHT_PX
 
 
 def title_card(title_text: str, subtitle_text: str | None = None, **kwargs):
-    """Create a styled title card.
+    """Create a compact page heading.
+
+    A plain left-aligned heading rather than the previous full-width red
+    banner, so pages lead with their content instead of their title.
 
     Args:
         title_text: Main title text
         subtitle_text: Optional subtitle text
-        **kwargs: Additional keyword arguments for dmc.Paper
+        **kwargs: Additional keyword arguments for dmc.Box
 
     Returns
     -------
-        dmc.Paper component styled as a title card
+        dmc.Box containing the page heading
     """
-    children = []
-    children.append(
+    children = [
         dmc.Title(
             title_text,
             order=1,
-            style={"marginBottom": "0px", "fontSize": "90px"},
+            fz=26,
+            fw=700,
+            style={"letterSpacing": "-0.02em"},
         )
-    )
+    ]
     if subtitle_text:
-        children.append(
-            dmc.Text(
-                subtitle_text,
-            )
-        )
+        children.append(dmc.Text(subtitle_text, size="sm", c="dimmed"))
 
-    return dmc.Paper(
-        children=dmc.Stack(
-            children=children,
-            align="center",
-        ),
-        p="xl",
-        radius=28,
-        style={
-            "backgroundColor": "var(--tarxiv-color-primary)",
-            "color": "white",
-            "textAlign": "center",
-        },
-        **kwargs,
-    )
+    kwargs.setdefault("mb", "xs")
+    return dmc.Box(children=dmc.Stack(children=children, gap=2), **kwargs)
 
 
 def footer_card():
@@ -74,10 +71,10 @@ def footer_card():
             align="center",
             direction="row",
         ),
-        p="xl",
+        p="md",
+        radius=14,
         style={
             "backgroundColor": "var(--tarxiv-footer-bg)",
-            "color": "var(--tarxiv-color-primary)",
             "textAlign": "center",
         },
         mt="md",
@@ -85,14 +82,25 @@ def footer_card():
 
 
 def expressive_card(
-    children, title=None, title_order: Literal[1, 2, 3, 4, 5, 6] = 2, **kwargs
+    children,
+    title=None,
+    title_order: Literal[1, 2, 3, 4, 5, 6] = 2,
+    header_extra=None,
+    body_padding: str | int = "md",
+    **kwargs,
 ):
-    """Create a styled card with expressive design.
+    """Create the standard surface card.
+
+    A bordered, softly shadowed 14px-radius card. When a title is given it sits
+    in a divider-separated header row, optionally alongside ``header_extra``
+    (a control such as a toggle or copy button) pinned to the right.
 
     Args:
         children: List of child components
-        title: Optional title for the card
+        title: Optional title for the card header
         title_order: Heading order (1-6)
+        header_extra: Optional component placed at the right of the header
+        body_padding: Padding for the card body (0 lets a child bleed to the edge)
         **kwargs: Additional keyword arguments for dmc.Paper
 
     Returns
@@ -102,102 +110,35 @@ def expressive_card(
     if not isinstance(children, list):
         children = [children]
 
+    card_children = []
+    if title:
+        header = [
+            dmc.Title(title, order=title_order, fz=13, fw=600),
+            dmc.Box(style={"flex": 1}),
+        ]
+        if header_extra is not None:
+            header.append(header_extra)
+        card_children.append(html.Div(header, className="tarxiv-card-head"))
+
+    card_children.append(
+        dmc.Box(dmc.Stack(children=children, gap="md"), p=body_padding)
+    )
+
+    # Merge rather than clobber any caller-supplied style.
+    style = {
+        "backgroundColor": "var(--tarxiv-card)",
+        "border": "1px solid var(--tarxiv-border)",
+        "boxShadow": "var(--tarxiv-shadow)",
+        "overflow": "hidden",
+        **(kwargs.pop("style", None) or {}),
+    }
+
     return dmc.Paper(
-        children=[
-            dmc.Title(
-                title,
-                order=title_order,
-                # fw=700,
-                # fz="lg",
-                mb="md",
-            )
-            if title
-            else None,
-            dmc.Stack(
-                children=children,
-                gap="md",
-            ),
-        ],
-        p="xl",
-        radius=28,  # Specific M3 Expressive radius
-        style={
-            "backgroundColor": "var(--tarxiv-card-1)",
-        },
+        children=card_children,
+        p=0,
+        radius=14,
+        style=style,
         **kwargs,
-    )
-
-
-def create_nav_item(
-    icon,
-    label: str,
-    is_active: bool,
-    id: str = "",
-):
-    icon_container = (
-        DashIconify(icon=icon, width=35, id=id)
-        if isinstance(icon, str)
-        else html.Div(
-            icon,
-            style={
-                "width": "35px",
-                "height": "35px",
-                "display": "flex",
-                "alignItems": "center",
-                "justifyContent": "center",
-            },
-        )
-    )
-
-    return dmc.UnstyledButton(
-        className="nav-item-hover",
-        px=2,
-        py="md",
-        my="xs",
-        style={
-            "width": "100%",
-            "borderRadius": "16px",
-            "display": "flex",
-            "flexDirection": "column",
-            "alignItems": "center",
-            "gap": "4px",
-            "color": "var(--tarxiv-color-primary)" if is_active else "inherit",
-            "transition": "background-color 200ms ease",
-        },
-        children=[
-            icon_container,
-            dmc.Text(
-                label,
-                size="xs",
-                ta="center",
-                className="nav-text-wrap",
-            ),
-        ],
-    )
-
-
-def create_nav_link(
-    icon: str,
-    label: str,
-    href: str,
-    is_active: bool,
-    id: str = "",
-):
-    """Creates a vertically stacked navigation button.
-
-    Args:
-        icon: Icon name for DashIconify
-        label: Text label for the nav item
-        href: Link URL
-        is_active: Whether this nav item is active
-
-    Returns
-    -------
-        dcc.Link containing a styled dmc.UnstyledButton
-    """
-    return dcc.Link(
-        href=href,
-        style={"textDecoration": "none", "color": "inherit"},
-        children=create_nav_item(icon, label, is_active, id=id),
     )
 
 
@@ -221,36 +162,32 @@ def create_message_banner(
     -------
         html.Div with styled message
     """
+    # Let Mantine theme the alert so it adapts to the colour scheme, instead of
+    # the hardcoded light-only palette this used to carry.
     color_map = {
-        "success": {"bg": "#d4edda", "border": "#c3e6cb", "text": "#155724"},
-        "error": {"bg": "#f8d7da", "border": "#f5c6cb", "text": "#721c24"},
-        "warning": {"bg": "#fff3cd", "border": "#ffeaa7", "text": "#856404"},
-        "info": {"bg": "#d1ecf1", "border": "#bee5eb", "text": "#0c5460"},
+        "success": "green",
+        "error": "red",
+        "warning": "yellow",
+        "info": "blue",
+    }
+    icon_map = {
+        "success": "mdi:check-circle-outline",
+        "error": "mdi:alert-circle-outline",
+        "warning": "mdi:alert-outline",
+        "info": "mdi:information-outline",
     }
 
-    colors = color_map.get(message_type, color_map["info"])
-
     return dmc.Alert(
-        # message,
         title=message.capitalize(),
-        style={
-            "padding": "12px 20px",
-            "border": f"1px solid {colors['border']}",
-            "borderRadius": "4px",
-            "backgroundColor": colors["bg"],
-            "color": colors["text"],
-            "fontSize": "14px",
-            "fontWeight": "500",
-        },
+        color=color_map.get(message_type, color_map["info"]),
+        variant="light",
+        radius="md",
+        icon=DashIconify(icon=icon_map.get(message_type, icon_map["info"]), width=20),
         id=id,
         hide=hide,
         duration=duration,
     )
 
-
-# Shared height (px) for the Aladin sky-plot pane and the scrollable metadata
-# pane beside it, so the two columns line up.
-ALADIN_HEIGHT_PX = 500
 
 # Source key -> display label for the per-source metadata tabs.
 SOURCE_LABELS = {
@@ -292,6 +229,9 @@ FIELD_LABELS = {
     "discovery_data_source": "Discovery Data Source",
     "redshift": "Redshift",
     "host_name": "Host Name",
+    # The TNS ingest writes the host under "hostname"; label it properly rather
+    # than letting it fall through to the title-cased "Hostname".
+    "hostname": "Host Name",
     "mag": "Magnitude",
     "mag_err": "Magnitude Error",
     "mag_filter": "Magnitude Filter",
@@ -307,10 +247,15 @@ FIELD_LABELS = {
     "north_separation_arcsec": "North Separation (arcsec)",
     "east_separation_arcsec": "East Separation (arcsec)",
     "physical_separation_kpc": "Physical Separation (kpc)",
-    # List-valued photometry fields and their per-entry columns.
+    # List-valued photometry fields and their per-entry columns. summarize_lc_mags
+    # emits the plural keys, so label both spellings.
     "peak_mag": "Peak Magnitude",
+    "peak_mags": "Peak Magnitudes",
     "latest_detection": "Latest Detection",
+    "latest_detections": "Latest Detections",
     "latest_nondetection": "Latest Non-detection",
+    "latest_non_detections": "Latest Non-detections",
+    "limit": "Magnitude",
     "filter": "Filter",
     "date": "Date",
     "value": "Magnitude",
@@ -358,7 +303,8 @@ def _build_scalar_table(source_payload: dict):
             [
                 dmc.TableThead(
                     dmc.TableTr([
-                        dmc.TableTh("Field"),
+                        # Keep the label column narrow so values get the room.
+                        dmc.TableTh("Field", w="38%"),
                         dmc.TableTh("Value"),
                     ])
                 ),
@@ -370,13 +316,11 @@ def _build_scalar_table(source_payload: dict):
                     for field_name, value in rows
                 ]),
             ],
-            withTableBorder=True,
-            withColumnBorders=True,
-            striped=True,
             highlightOnHover=True,
-            horizontalSpacing="xs",
-            verticalSpacing="xs",
-            style={"width": "fit-content"},
+            horizontalSpacing="sm",
+            verticalSpacing=6,
+            fz="xs",
+            style={"width": "100%"},
         ),
     )
 
@@ -420,21 +364,26 @@ def _build_list_table(field_name: str, entries: list):
 
     return dmc.Stack(
         [
-            dmc.Text(_field_label(field_name), fw=600),
+            dmc.Text(
+                _field_label(field_name),
+                fw=600,
+                fz="10.5px",
+                c="dimmed",
+                tt="uppercase",
+                style={"letterSpacing": "0.06em"},
+            ),
             dmc.Box(
                 dmc.Table(
                     [header, dmc.TableTbody(body_rows)],
-                    withTableBorder=True,
-                    withColumnBorders=True,
-                    striped=True,
                     highlightOnHover=True,
-                    horizontalSpacing="xs",
-                    verticalSpacing="xs",
-                    style={"width": "fit-content"},
+                    horizontalSpacing="sm",
+                    verticalSpacing=6,
+                    fz="xs",
+                    style={"width": "100%"},
                 )
             ),
         ],
-        gap="xs",
+        gap=4,
     )
 
 
@@ -526,81 +475,89 @@ def _build_citation_component(citation_str: str | None):
     return body
 
 
-def format_object_metadata(object_id, meta, citation_str=None, logger=None):
+def format_object_metadata(
+    object_id, meta, citation_str=None, lc_data=None, logger=None
+):
     """Format object metadata for display.
+
+    Builds the "balanced" object page: a compact identity row and key-facts
+    strip, then the lightcurve and sky view side by side above the fold, with
+    the per-source metadata, citations and raw JSON below.
 
     Args:
         object_id: Object identifier
         meta: Metadata dictionary (source-keyed schema, see MetadataResponseModel)
         citation_str: Optional concatenated BibTeX citation string
+        lc_data: Optional photometry list, used for the detection-count fact
         logger: Optional logger instance
 
     Returns
     -------
-        A ``(results_top, citations_card, full_metadata)`` tuple. The caller
-        composes these into the page: ``results_top`` (lightcurve + sky-plot /
-        metadata) goes in the results container, ``citations_card`` sits in a
-        grid beside the (always-present) ``object-tagging-container``, and
-        ``full_metadata`` is the collapsible JSON dump pinned to the page bottom.
-        Splitting the output this way lets the tagging container live in the base
-        layout so its callbacks never target a missing component.
+        A ``(results_top, metadata_card, citations_card, full_metadata)`` tuple.
+        The caller composes these into the page: ``results_top`` (head, key
+        facts, lightcurve + sky view) goes in the results container, while
+        ``metadata_card`` and ``citations_card`` sit in the lower grid beside
+        the (always-present) ``object-tagging-container`` and ``full_metadata``
+        is the collapsible JSON dump pinned to the page bottom. Splitting the
+        output this way lets the tagging container live in the base layout so
+        its callbacks never target a missing component.
     """
     data_sources = meta.get("data_sources") or {}
 
     metadata_component = _build_metadata_tabs(data_sources)
     citations_component = _build_citation_component(citation_str)
 
-    # Prominent, copyable RA/Dec (sexagesimal HMS + DMS) sits above the lightcurve.
     lightcurve_card = expressive_card(
-        children=[
-            _build_coordinates_header(meta),
-            dcc.Loading(
-                dcc.Graph(id={"type": "themeable-plot", "index": "lightcurve-plot"}),
-            ),
-        ],
-        title=f"Lightcurve: {object_id}",
+        children=build_lightcurve_body(),
+        title="Lightcurve",
+        header_extra=build_view_toggle(),
+        body_padding="xs",
     )
-    aladin_card = expressive_card(
+    sky_card = expressive_card(
         children=[
             # A hidden div to receive the "success" message from our JS
             html.Div(id="aladin-status-dummy", style={"display": "none"}),
             html.Div(
                 id="aladin-lite-div",
-                style={"width": "100%", "height": f"{ALADIN_HEIGHT_PX}px"},
+                style={"width": "100%", "height": f"{PLOT_HEIGHT_PX}px"},
             ),
         ],
-        title="Sky Plot (Aladin Lite)",
+        title="Sky view",
+        header_extra=dmc.Text("PanSTARRS DR1", size="xs", c="dimmed", ff="monospace"),
+        body_padding=0,
     )
 
-    # Constrain the metadata pane to the Aladin height and scroll any overflow,
-    # so a source with many fields doesn't stretch the page.
+    results_top = dmc.Stack(
+        [
+            build_page_head(object_id, meta, _build_coordinates_header(meta)),
+            build_summary_strip(build_key_facts(meta, lc_data)),
+            build_hero_grid(object_id, lightcurve_card, sky_card),
+        ],
+        gap="md",
+    )
+
+    # Constrain the metadata pane and scroll any overflow, so a source with
+    # many fields doesn't stretch the page.
     metadata_card = expressive_card(
         children=dmc.ScrollArea(
             metadata_component,
-            h=ALADIN_HEIGHT_PX,
+            h=420,
             type="auto",
             offsetScrollbars=True,
         ),
-        title=f"Object Metadata: {object_id}",
-    )
-
-    results_top = dmc.Stack([
-        # Lightcurve spans the full width; the metadata pairs with the sky plot.
-        lightcurve_card,
-        # Per-source metadata on the left, Aladin sky-plot on the right.
-        dmc.Grid(
-            [
-                dmc.GridCol(metadata_card, span=6),
-                dmc.GridCol(aladin_card, span=6),
-            ],
-            gutter="md",
+        title="Source metadata",
+        header_extra=dmc.Text(
+            " · ".join(_source_label(key) for key in _ordered_sources(data_sources))
+            or "no sources",
+            size="xs",
+            c="dimmed",
         ),
-    ])
+    )
 
     # Citations card (copyable BibTeX); the caller pairs it with the tagging panel.
     citations_card = expressive_card(
         children=citations_component,
-        title=f"Citations: {object_id}",
+        title="Citations",
     )
 
     # Full metadata JSON — collapsible, collapsed by default, at the very bottom.
@@ -616,10 +573,9 @@ def format_object_metadata(object_id, meta, citation_str=None, logger=None):
                         dmc.Code(
                             json.dumps(meta, indent=2),
                             style={
-                                "padding": "10px",
+                                "padding": "12px",
                                 "maxHeight": "400px",
                                 "overflow": "auto",
-                                "borderRadius": "4px",
                             },
                             block=True,
                         ),
@@ -629,7 +585,7 @@ def format_object_metadata(object_id, meta, citation_str=None, logger=None):
         ],
     )
 
-    return results_top, citations_card, full_metadata
+    return results_top, metadata_card, citations_card, full_metadata
 
 
 def _build_coordinates_header(meta):

--- a/tarxiv/dashboard/components/cards.py
+++ b/tarxiv/dashboard/components/cards.py
@@ -216,7 +216,10 @@ def create_message_banner(
     }
 
     return dmc.Alert(
-        title=message.capitalize(),
+        # Uppercase the first letter only — str.capitalize() lowercases the
+        # rest, which mangles the acronyms these messages are full of
+        # ("RA" -> "ra", "TarXiv" -> "tarxiv").
+        title=message[:1].upper() + message[1:],
         color=color_map.get(message_type, color_map["info"]),
         variant="light",
         radius="md",

--- a/tarxiv/dashboard/components/object_view.py
+++ b/tarxiv/dashboard/components/object_view.py
@@ -1,0 +1,433 @@
+"""Builders for the object (lightcurve) page.
+
+The page follows the "balanced" layout: a compact head row, a strip of key
+facts, then the lightcurve and sky view side by side above the fold, with the
+full per-source metadata, tags and citations below.
+
+Everything here is a pure function of the metadata/photometry documents so the
+layout can be unit tested without a running Dash app.
+"""
+
+import dash_mantine_components as dmc
+from dash import dcc, html
+from dash_iconify import DashIconify
+
+from ..styles import band_color
+from .plots import PLOT_HEIGHT_PX, series_label
+
+# Placeholder for any missing value; matches cards.EM_DASH.
+EM_DASH = "—"
+
+
+# --------------------------------------------------------------------------
+# Key facts
+# --------------------------------------------------------------------------
+
+
+def _sources(meta: dict) -> dict:
+    sources = meta.get("data_sources") or {}
+    return sources if isinstance(sources, dict) else {}
+
+
+def _first_present(meta: dict, source_keys: list[str], field: str):
+    """First non-None ``field`` across the named sources, in preference order."""
+    sources = _sources(meta)
+    for key in source_keys:
+        payload = sources.get(key)
+        if isinstance(payload, dict) and payload.get(field) is not None:
+            return payload[field]
+    return None
+
+
+def _fact(label: str, value, unit: str | None = None) -> dict:
+    return {
+        "label": label,
+        "value": EM_DASH if value is None or value == "" else str(value),
+        "unit": unit,
+    }
+
+
+def _format_number(value, spec: str):
+    """Format a value with ``spec`` when it is numeric, else pass it through."""
+    try:
+        return format(float(value), spec)
+    except (TypeError, ValueError):
+        return value
+
+
+def _peak_magnitude(meta: dict) -> tuple[float | None, str | None]:
+    """Brightest (numerically smallest) peak magnitude across all sources.
+
+    ``summarize_lc_mags`` (tarxiv/data_sources.py) writes a ``peak_mags`` list
+    per survey payload, and stores the magnitude value under the key ``limit``
+    rather than ``mag``. Handle both so this keeps working if that is fixed.
+    """
+    best_mag: float | None = None
+    best_filter: str | None = None
+
+    for payload in _sources(meta).values():
+        if not isinstance(payload, dict):
+            continue
+        entries = payload.get("peak_mags") or payload.get("peak_mag") or []
+        if isinstance(entries, dict):
+            entries = [entries]
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            raw = entry.get("limit", entry.get("mag", entry.get("value")))
+            try:
+                mag = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if best_mag is None or mag < best_mag:
+                best_mag = mag
+                best_filter = entry.get("filter")
+
+    return best_mag, best_filter
+
+
+def _detection_summary(lc_data) -> tuple[int | None, str | None]:
+    """Count detections and list the surveys contributing them."""
+    if not lc_data:
+        return None, None
+
+    count = 0
+    surveys: set[str] = set()
+    for point in lc_data:
+        if not isinstance(point, dict):
+            continue
+        if point.get("detection") == 1:
+            count += 1
+            survey = point.get("survey")
+            if survey:
+                surveys.add(str(survey).upper())
+
+    unit = " + ".join(sorted(surveys)) if surveys else None
+    return count, unit
+
+
+def build_key_facts(meta: dict, lc_data=None) -> list[dict]:
+    """Build the six summary facts shown in the strip under the page head.
+
+    Returns a list of ``{"label", "value", "unit"}`` dicts, using an em-dash
+    for anything the record does not carry.
+    """
+    meta = meta or {}
+
+    # TNS is the authoritative classification source; Sherlock is the fallback.
+    redshift = _first_present(meta, ["tns", "sherlock"], "redshift")
+
+    # TNS writes the host under "hostname" (not "host_name").
+    host = _first_present(meta, ["tns"], "hostname") or _first_present(
+        meta, ["tns"], "host_name"
+    )
+    if host is None:
+        host = _first_present(meta, ["sherlock"], "catalogue_object_id")
+
+    discovery = meta.get("discovery_date") or _first_present(
+        meta, ["tns"], "discovery_date"
+    )
+    if isinstance(discovery, str) and discovery:
+        # Trim "2023-05-19 17:27:15" / ISO "T" forms down to the date.
+        discovery = discovery.replace("T", " ").split(" ")[0]
+    reporting_group = _first_present(meta, ["tns"], "reporting_group")
+
+    peak_mag, peak_filter = _peak_magnitude(meta)
+    distance = _first_present(meta, ["sherlock"], "best_distance")
+    detections, detection_surveys = _detection_summary(lc_data)
+
+    return [
+        _fact("Redshift", _format_number(redshift, ".4g") if redshift else None),
+        _fact("Host", host),
+        _fact("Discovered", discovery, reporting_group),
+        _fact(
+            "Peak mag",
+            f"{peak_mag:.1f}" if peak_mag is not None else None,
+            peak_filter,
+        ),
+        _fact(
+            "Distance",
+            _format_number(distance, ".2f") if distance is not None else None,
+            "Mpc" if isinstance(distance, (int, float)) else None,
+        ),
+        _fact("Detections", detections, detection_surveys),
+    ]
+
+
+# --------------------------------------------------------------------------
+# Layout pieces
+# --------------------------------------------------------------------------
+
+
+def _search_controls(prefill: str | None = None, width: int = 220, size: str = "xs"):
+    """Object-ID search input + button.
+
+    Keeps the ``object-id-input`` / ``search-id-keyboard`` / ``search-id-button``
+    ids so the existing ``search_navigation`` callback drives navigation.
+    """
+    from dash_extensions import Keyboard
+
+    return [
+        Keyboard(
+            id="search-id-keyboard",
+            captureKeys=["Enter"],
+            n_keydowns=0,
+            children=[
+                dmc.TextInput(
+                    id="object-id-input",
+                    placeholder="Object ID, e.g. 2023ixf",
+                    value=prefill or "",
+                    size=size,
+                    w=width,
+                    leftSection=DashIconify(icon="mdi:magnify", width=16),
+                )
+            ],
+        ),
+        dmc.Button("Search", id="search-id-button", size=size, variant="default"),
+    ]
+
+
+def build_page_head(object_id: str, meta: dict, coordinates_header=None):
+    """Compact identity row: name, type chip, coordinates and search."""
+    object_type = _first_present(meta or {}, ["tns"], "object_type")
+
+    left = [
+        dmc.Title(object_id, order=1, fz=24, fw=700, style={"letterSpacing": "-0.02em"})
+    ]
+    if object_type:
+        left.append(
+            dmc.Badge(object_type, variant="light", color="arxiv_red", size="lg")
+        )
+    if coordinates_header is not None:
+        left.append(coordinates_header)
+
+    return dmc.Group(
+        [
+            dmc.Group(left, gap="sm", align="center", wrap="wrap"),
+            dmc.Group(
+                _search_controls(prefill=object_id),
+                gap="xs",
+                wrap="nowrap",
+                visibleFrom="sm",
+            ),
+        ],
+        justify="space-between",
+        align="center",
+        wrap="wrap",
+        gap="sm",
+    )
+
+
+def build_summary_strip(facts: list[dict]):
+    """Card-styled strip of key facts; the "no scrolling" payload."""
+    tiles = []
+    for index, fact in enumerate(facts):
+        value_children = [fact["value"]]
+        if fact.get("unit"):
+            value_children.append(
+                dmc.Text(fact["unit"], span=True, size="xs", c="dimmed", fw=500, ml=4)
+            )
+        tiles.append(
+            dmc.Box(
+                [
+                    dmc.Text(
+                        fact["label"],
+                        size="10.5px",
+                        fw=600,
+                        c="dimmed",
+                        tt="uppercase",
+                        style={"letterSpacing": "0.07em"},
+                    ),
+                    dmc.Text(value_children, size="15px", fw=600),
+                ],
+                # Hairline separators between tiles, not before the first.
+                pl="md" if index else 0,
+                style={
+                    "borderLeft": "1px solid var(--tarxiv-border)" if index else "none",
+                    "minWidth": 0,
+                },
+            )
+        )
+
+    return dmc.Paper(
+        dmc.SimpleGrid(tiles, cols={"base": 2, "sm": 3, "lg": 6}, spacing="md"),
+        p="md",
+        radius=14,
+        style={
+            "backgroundColor": "var(--tarxiv-card)",
+            "border": "1px solid var(--tarxiv-border)",
+            "boxShadow": "var(--tarxiv-shadow)",
+        },
+    )
+
+
+def build_hero_grid(object_id: str, lightcurve_card, sky_card):
+    """Lightcurve (7 cols) beside the sky view (5 cols), equal heights."""
+    return dmc.Grid(
+        [
+            dmc.GridCol(lightcurve_card, span={"base": 12, "lg": 7}),
+            dmc.GridCol(sky_card, span={"base": 12, "lg": 5}),
+        ],
+        gutter="md",
+        align="stretch",
+    )
+
+
+def build_lightcurve_body():
+    """Graph and (initially hidden) photometry table, toggled by the segment."""
+    return [
+        html.Div(
+            dcc.Loading(
+                dcc.Graph(
+                    id={"type": "themeable-plot", "index": "lightcurve-plot"},
+                    style={"height": f"{PLOT_HEIGHT_PX}px", "width": "100%"},
+                    config={"responsive": True, "displaylogo": False},
+                ),
+                type="default",
+            ),
+            id="lc-plot-wrap",
+        ),
+        html.Div(id="lc-table-wrap", style={"display": "none"}),
+    ]
+
+
+def build_view_toggle():
+    """Plot/Table switch for the lightcurve card header.
+
+    The table is also the accessible fallback for the two band colours that
+    sit below 3:1 contrast on the light surface (see styles.BAND_COLORS).
+    """
+    return dmc.SegmentedControl(
+        id="lc-view-toggle",
+        value="Plot",
+        data=["Plot", "Table"],
+        size="xs",
+        radius="md",
+    )
+
+
+def build_photometry_table(lc_data, scheme: str = "light"):
+    """Sortable-by-epoch photometry table used by the Table view."""
+    rows = []
+    for point in lc_data or []:
+        if not isinstance(point, dict):
+            continue
+        detection = point.get("detection")
+        mjd = point.get("mjd")
+        if mjd is None or detection not in (0, 1):
+            # -1 marks bad-quality points, which the plot also drops.
+            continue
+
+        band = point.get("filter")
+        survey = point.get("survey")
+        if detection == 1:
+            mag = point.get("mag")
+            mag_text = f"{mag:.2f}" if isinstance(mag, (int, float)) else EM_DASH
+            err = point.get("mag_err")
+            err_text = f"{err:.2f}" if isinstance(err, (int, float)) else EM_DASH
+            kind = "detection"
+        else:
+            limit = point.get("limit")
+            mag_text = f"> {limit:.2f}" if isinstance(limit, (int, float)) else EM_DASH
+            err_text = EM_DASH
+            kind = "limit"
+
+        rows.append((
+            mjd,
+            dmc.TableTr([
+                dmc.TableTd(f"{mjd:.2f}", ff="monospace"),
+                dmc.TableTd(
+                    dmc.Group(
+                        [
+                            dmc.Box(
+                                w=9,
+                                h=9,
+                                style={
+                                    "backgroundColor": band_color(band, scheme),
+                                    "borderRadius": "3px",
+                                    "flexShrink": 0,
+                                },
+                            ),
+                            dmc.Text(series_label(survey, band), size="xs"),
+                        ],
+                        gap=7,
+                        wrap="nowrap",
+                    )
+                ),
+                dmc.TableTd(mag_text, ff="monospace"),
+                dmc.TableTd(err_text, ff="monospace"),
+                dmc.TableTd(dmc.Text(kind, size="xs", c="dimmed")),
+            ]),
+        ))
+
+    if not rows:
+        return dmc.Box(
+            dmc.Text("No photometry available", size="sm", c="dimmed", ta="center"),
+            py="xl",
+        )
+
+    rows.sort(key=lambda item: item[0])
+
+    return dmc.ScrollArea(
+        dmc.Table(
+            [
+                dmc.TableThead(
+                    dmc.TableTr([
+                        dmc.TableTh("MJD"),
+                        dmc.TableTh("Filter"),
+                        dmc.TableTh("Mag"),
+                        dmc.TableTh("σ"),
+                        dmc.TableTh("Type"),
+                    ])
+                ),
+                dmc.TableTbody([row for _, row in rows]),
+            ],
+            highlightOnHover=True,
+            stickyHeader=True,
+            fz="xs",
+            verticalSpacing=6,
+        ),
+        h=PLOT_HEIGHT_PX,
+        type="auto",
+        offsetScrollbars=True,
+    )
+
+
+def build_empty_search_state(prefill: str | None = None):
+    """Centred search card shown when no object is selected."""
+    return dmc.Center(
+        dmc.Paper(
+            dmc.Stack(
+                [
+                    dmc.Title("Explore a transient", order=2, fz=22, ta="center"),
+                    dmc.Text(
+                        "Enter a TarXiv or survey object ID to see its lightcurve, "
+                        "sky position and cross-matched metadata.",
+                        size="sm",
+                        c="dimmed",
+                        ta="center",
+                        maw=420,
+                    ),
+                    dmc.Group(
+                        _search_controls(prefill=prefill, width=280, size="sm"),
+                        gap="xs",
+                        justify="center",
+                    ),
+                ],
+                gap="md",
+                align="center",
+            ),
+            p="xl",
+            radius=14,
+            maw=560,
+            w="100%",
+            style={
+                "backgroundColor": "var(--tarxiv-card)",
+                "border": "1px solid var(--tarxiv-border)",
+                "boxShadow": "var(--tarxiv-shadow)",
+            },
+        ),
+        py=40,
+    )

--- a/tarxiv/dashboard/components/object_view.py
+++ b/tarxiv/dashboard/components/object_view.py
@@ -189,8 +189,26 @@ def _search_controls(prefill: str | None = None, width: int = 220, size: str = "
     ]
 
 
-def build_page_head(object_id: str, meta: dict, coordinates_header=None):
-    """Compact identity row: name, type chip, coordinates and search."""
+def build_tag_chips(assigned_tags):
+    """Read-only tag chips for the page head.
+
+    Deliberately without remove buttons: the tag card owns management, and its
+    remove controls use pattern-matching ids that would collide if a second set
+    were rendered here.
+    """
+    from .cards import tag_badge
+
+    return [tag_badge(item["tag"], size="sm") for item in (assigned_tags or [])]
+
+
+def build_page_head(
+    object_id: str, meta: dict, coordinates_header=None, assigned_tags=None
+):
+    """Compact identity row: name, type badge, tags, coordinates and actions.
+
+    Object search lives in the app header, so it is deliberately not repeated
+    here; the right-hand side carries the object actions instead.
+    """
     object_type = _first_present(meta or {}, ["tns"], "object_type")
 
     left = [
@@ -200,18 +218,64 @@ def build_page_head(object_id: str, meta: dict, coordinates_header=None):
         left.append(
             dmc.Badge(object_type, variant="light", color="arxiv_red", size="lg")
         )
+    left.append(
+        dmc.Group(
+            build_tag_chips(assigned_tags),
+            id="object-tag-chips",
+            gap=6,
+            wrap="wrap",
+        )
+    )
     if coordinates_header is not None:
         left.append(coordinates_header)
+
+    actions = dmc.Group(
+        [
+            # Dummy sink for the scroll-to-tags clientside callback.
+            html.Div(id="tag-scroll-dummy", style={"display": "none"}),
+            dmc.Button(
+                "Tag",
+                id="jump-to-tags",
+                n_clicks=0,
+                size="xs",
+                variant="light",
+                color="arxiv_red",
+                leftSection=DashIconify(icon="mdi:tag-plus-outline", width=15),
+            ),
+            # Copies the citations card's BibTeX block directly. dcc.Clipboard
+            # reads the target element's text, so no callback is needed; it is
+            # stretched invisibly over the button to act as its click target.
+            dmc.Button(
+                [
+                    "Cite",
+                    dcc.Clipboard(
+                        id="cite-copy",
+                        target_id="citation-bibtex",
+                        title="Copy BibTeX",
+                        style={
+                            "position": "absolute",
+                            "inset": 0,
+                            "width": "100%",
+                            "height": "100%",
+                            "opacity": 0,
+                            "cursor": "pointer",
+                        },
+                    ),
+                ],
+                size="xs",
+                variant="default",
+                leftSection=DashIconify(icon="mdi:format-quote-close", width=15),
+                style={"position": "relative"},
+            ),
+        ],
+        gap="xs",
+        wrap="nowrap",
+    )
 
     return dmc.Group(
         [
             dmc.Group(left, gap="sm", align="center", wrap="wrap"),
-            dmc.Group(
-                _search_controls(prefill=object_id),
-                gap="xs",
-                wrap="nowrap",
-                visibleFrom="sm",
-            ),
+            actions,
         ],
         justify="space-between",
         align="center",

--- a/tarxiv/dashboard/components/plots.py
+++ b/tarxiv/dashboard/components/plots.py
@@ -1,7 +1,19 @@
 """Plotting functions for the dashboard."""
 
 import plotly.graph_objects as go
-from .theme_manager import apply_theme, get_filter_style
+
+from ..styles import COLORS, resolve_filter_style
+from .theme_manager import apply_theme, scheme_from_template
+
+# Height of the lightcurve figure, matched to the sky-view card beside it.
+PLOT_HEIGHT_PX = 430
+
+
+def series_label(survey_name: str | None, filter_name: str | None) -> str:
+    """Legend/table label for a (survey, band) series, e.g. "ZTF g"."""
+    survey = (survey_name or "Unknown").upper()
+    band = filter_name or "Unknown"
+    return f"{survey} {band}"
 
 
 def empty_lightcurve_plot(
@@ -15,7 +27,7 @@ def empty_lightcurve_plot(
     obvious.
 
     Args:
-        object_id: Object identifier (used in the title)
+        object_id: Object identifier (used for logging)
         theme_template: Theme template for styling
         message: Text shown in the centre of the plot
         logger: Optional logger instance
@@ -29,10 +41,11 @@ def empty_lightcurve_plot(
             "warning": f"No lightcurve data to plot for object: {object_id}"
         })
 
+    scheme = scheme_from_template(theme_template)
+
     fig = go.Figure()
     fig.update_layout(
-        title=f"Lightcurve: {object_id}",
-        height=500,
+        height=PLOT_HEIGHT_PX,
         xaxis=dict(visible=False),
         yaxis=dict(visible=False),
         shapes=[
@@ -44,8 +57,8 @@ def empty_lightcurve_plot(
                 y0=0,
                 x1=1,
                 y1=1,
-                fillcolor="gray",
-                opacity=0.12,
+                fillcolor=COLORS[scheme]["card_2"],
+                opacity=0.6,
                 line=dict(width=0),
                 layer="below",
             )
@@ -58,7 +71,7 @@ def empty_lightcurve_plot(
                 x=0.5,
                 y=0.5,
                 showarrow=False,
-                font=dict(size=18, color="gray"),
+                font=dict(size=15, color=COLORS[scheme]["ink_3"]),
             )
         ],
     )
@@ -67,6 +80,10 @@ def empty_lightcurve_plot(
 
 def create_lightcurve_plot(lc_data, object_id, theme_template, logger=None):
     """Create a lightcurve plot from the data.
+
+    Colour encodes the photometric band and marker symbol encodes the survey
+    (see ``styles.resolve_filter_style``), so the same bandpass observed by two
+    surveys shares a colour and is told apart by shape.
 
     Args:
         lc_data: List of photometry points
@@ -83,6 +100,9 @@ def create_lightcurve_plot(lc_data, object_id, theme_template, logger=None):
         return empty_lightcurve_plot(object_id, theme_template, logger=logger)
 
     fig = go.Figure()
+    scheme = scheme_from_template(theme_template)
+    surface = COLORS[scheme]["card"]
+
     if logger:
         logger.debug({
             "debug": f"Creating lightcurve plot for object: {object_id} with {len(lc_data)} points"
@@ -129,48 +149,78 @@ def create_lightcurve_plot(lc_data, object_id, theme_template, logger=None):
     for (filter_name, survey_name), data in sorted(
         grouped_data.items(), key=lambda x: (x[0][1], x[0][0])
     ):
-        # color = FILTER_COLORS.get(filter_name, "gray")
-        survey_label = survey_name.upper()
+        style = resolve_filter_style(survey_name, filter_name)
+        color = style[scheme]
+        label = series_label(survey_name, filter_name)
+        survey_label = (survey_name or "Unknown").upper()
 
         # Plot detections
         if data["mag"]:
+            has_errors = any(data["mag_err"])
             error_y = (
-                dict(type="data", array=data["mag_err"], visible=True)
-                if any(data["mag_err"])
+                dict(
+                    type="data",
+                    array=data["mag_err"],
+                    visible=True,
+                    width=0,
+                    thickness=1.2,
+                    color=color,
+                )
+                if has_errors
                 else None
             )
+            if has_errors:
+                hovertemplate = (
+                    f"<b>{label}</b>  MJD %{{x:.2f}}<br>"
+                    "%{y:.2f} ± %{customdata:.2f} mag<extra></extra>"
+                )
+            else:
+                hovertemplate = (
+                    f"<b>{label}</b>  MJD %{{x:.2f}}<br>%{{y:.2f}} mag<extra></extra>"
+                )
 
             fig.add_trace(
                 go.Scatter(
                     x=data["mjd"],
                     y=data["mag"],
                     mode="markers",
-                    name=f"{filter_name}-band",
+                    name=label,
                     marker=dict(
                         size=8,
-                        color=get_filter_style(filter_name),
+                        color=color,
+                        symbol=style["symbol"],
+                        # Thin surface-coloured ring keeps dense epochs legible
+                        line=dict(width=1, color=surface),
                     ),
                     error_y=error_y,
+                    customdata=data["mag_err"],
+                    hovertemplate=hovertemplate,
                     legendgroup=survey_name,
                     legendgrouptitle_text=survey_label,
                 )
             )
 
-        # Plot limits
+        # Plot limits (non-detections). These share the band colour and are
+        # hollow downward triangles; they stay out of the legend so it lists
+        # one entry per real series.
         if data["lim_mag"]:
             fig.add_trace(
                 go.Scatter(
                     x=data["lim_mjd"],
                     y=data["lim_mag"],
                     mode="markers",
-                    name=f"{filter_name}-band (limit)",
+                    name=f"{label} (limit)",
                     marker=dict(
-                        size=8,
-                        color=get_filter_style(filter_name),
-                        symbol="triangle-down",
-                        opacity=0.5,
+                        size=9,
+                        color=color,
+                        symbol="triangle-down-open",
+                        opacity=0.55,
                     ),
-                    showlegend=True,
+                    hovertemplate=(
+                        f"<b>{label}</b> non-detection  MJD %{{x:.2f}}<br>"
+                        "limit %{y:.2f} mag<extra></extra>"
+                    ),
+                    showlegend=False,
                     legendgroup=survey_name,
                     legendgrouptitle_text=survey_label,
                 )
@@ -181,22 +231,16 @@ def create_lightcurve_plot(lc_data, object_id, theme_template, logger=None):
     if not fig.data:
         return empty_lightcurve_plot(object_id, theme_template, logger=logger)
 
+    # Axis/legend/font/margin styling comes from the theme template; only the
+    # figure-specific bits are set here. The card header carries the title.
     fig.update_layout(
-        title=f"Lightcurve: {object_id}",
         xaxis_title="MJD",
-        xaxis_tickformat=".2f",
-        yaxis_title="Magnitude (mag)",
+        xaxis_tickformat="d",
+        yaxis_title="Apparent magnitude",
         yaxis=dict(autorange="reversed"),  # Magnitude scale is inverted
         hovermode="closest",
-        height=500,
-        legend=dict(
-            orientation="v",
-            yanchor="top",
-            y=1,
-            xanchor="left",
-            x=1.02,
-            groupclick="toggleitem",  # Allow clicking group title to toggle all items
-        ),
+        height=PLOT_HEIGHT_PX,
+        legend=dict(groupclick="toggleitem"),
     )
 
     fig = apply_theme(fig, theme_template)

--- a/tarxiv/dashboard/components/theme_manager.py
+++ b/tarxiv/dashboard/components/theme_manager.py
@@ -61,6 +61,17 @@ _LEGACY_ALIASES = {
 }
 
 _STATIC_CSS = """
+/* ------------------------------------------------------------- page plane */
+/* Mantine paints the body from its own `body` rule, which would otherwise win
+   on load order and leave the page pure white against white cards. The
+   :root[...] prefix raises specificity above a bare `body` selector so the
+   off-white plane holds whichever stylesheet lands last. */
+:root[data-mantine-color-scheme] body,
+:root[data-mantine-color-scheme] .mantine-AppShell-root,
+:root[data-mantine-color-scheme] .mantine-AppShell-main {
+    background-color: var(--tarxiv-bg);
+}
+
 /* ---------------------------------------------------------------- topbar */
 .tarxiv-wordmark {
     font-weight: 700;

--- a/tarxiv/dashboard/components/theme_manager.py
+++ b/tarxiv/dashboard/components/theme_manager.py
@@ -1,117 +1,105 @@
 import os
 
-from dash import html
 import plotly.io as pio
 import plotly.graph_objects as go
 
-from ..styles import COLORS, FILTER_COLORS
-from .cards import create_nav_item
+from ..styles import ARXIV_RED_RAMP, BAND_COLORS, COLORS, FOOTER_BG
 
+FONT_STACK = "'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif"
+MONO_STACK = "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace"
 
-brand_palette = [COLORS["primary"]] * 10
 THEME = {
     "primaryColor": "arxiv_red",
     "colors": {
-        "arxiv_red": brand_palette,
+        "arxiv_red": ARXIV_RED_RAMP,
     },
-    # Material 3 Expressive uses very rounded corners
-    "defaultRadius": "xl",
-    "white": COLORS["bg_light"],
-    "black": COLORS["bg_dark"],
-    # Customizing component defaults for that 'Expressive' feel
+    # Brand red is dark, so the dark scheme takes a lighter step.
+    "primaryShade": {"light": 6, "dark": 5},
+    "fontFamily": FONT_STACK,
+    "fontFamilyMonospace": MONO_STACK,
+    "headings": {"fontFamily": FONT_STACK, "fontWeight": "700"},
+    "defaultRadius": "md",
+    "white": COLORS["light"]["card"],
+    "black": COLORS["dark"]["bg"],
     "components": {
-        "Card": {
-            "defaultProps": {
-                "padding": "xl",
-                "shadow": "sm",
-                # "withBorder": True,
-            }
-        },
-        "TextInput": {
-            "defaultProps": {
-                "size": "md",
-                "labelProps": {"fz": "sm"},
-            }
-        },
-        "NumberInput": {
-            "defaultProps": {
-                "size": "md",
-                "labelProps": {"fz": "sm"},
-            }
-        },
-        "PasswordInput": {
-            "defaultProps": {
-                "size": "md",
-            }
-        },
-        "Button": {
-            "defaultProps": {
-                # "fw": 600,
-                "size": "md",
-            }
-        },
+        "Card": {"defaultProps": {"padding": "md", "radius": 14}},
+        "Paper": {"defaultProps": {"radius": 14}},
+        "TextInput": {"defaultProps": {"size": "sm", "labelProps": {"fz": "sm"}}},
+        "NumberInput": {"defaultProps": {"size": "sm", "labelProps": {"fz": "sm"}}},
+        "PasswordInput": {"defaultProps": {"size": "sm"}},
+        "Select": {"defaultProps": {"size": "sm"}},
+        "Button": {"defaultProps": {"size": "sm"}},
     },
 }
 
-
-def generate_css():
-    """Generates CSS variables for light and dark themes."""
-    light_css = f"""
-:root[data-mantine-color-scheme="light"] {{
-    --mantine-color-bg: {COLORS["bg_light"]};
-    --mantine-color-body: {COLORS["bg_light"]};
-    --mantine-color-text: {COLORS["bg_dark"]};
-    --tarxiv-color-primary: {COLORS["primary"]};
-    --tarxiv-card-1: {COLORS["card_light"]};
-    --tarxiv-footer-bg: {COLORS["card_dark"]};
-    --tarxiv-surface-1: {COLORS["vlight_gray"]};
-    --tarxiv-surface-2: {COLORS["surface_light"]};
-}}
-
-"""
-    #     light_css = f"""
-    # [data-mantine-color-scheme="light"] {{
-    #     --mantine-color-bg: {COLORS["bg_light"]};
-    #     --mantine-color-body: {COLORS["bg_light"]};
-    #     --mantine-color-text: {COLORS["bg_dark"]};
-    #     --tarxiv-card-1: {COLORS["card_light"]};
-    # }}
-
-    # """
-
-    dark_css = f"""
-:root[data-mantine-color-scheme="dark"] {{
-    --mantine-color-bg: {COLORS["bg_dark"]};
-    --mantine-color-body: {COLORS["bg_dark"]};
-    --mantine-color-text: {COLORS["bg_light"]};
-    --tarxiv-color-primary: {COLORS["primary"]};
-    --tarxiv-card-1: {COLORS["card_dark"]};
-    --tarxiv-footer-bg: {COLORS["bg_dark"]};
-    --tarxiv-surface-1: {COLORS["surface_dark"]};
-    --tarxiv-surface-2: {COLORS["surface_dark"]};
-}}
-
-"""
-
-    nav_hover = """
-/* Only apply hover colors on devices with a mouse/pointer */
-@media (hover: hover) {
-    .nav-item-hover:hover {
-        background-color: var(--mantine-color-bg);
-        transform: scale(1.03);
-        transition: transform 200ms ease;
-    }
-
-    /* Change the icon/text color on hover */
-    .nav-item-hover:hover * {
-        color: var(--mantine-color-indigo-6);
-    }
+# CSS custom property name -> key in COLORS[scheme]. Emitted for both schemes.
+_CSS_VARS = {
+    "--tarxiv-bg": "bg",
+    "--tarxiv-card": "card",
+    "--tarxiv-card-2": "card_2",
+    "--tarxiv-border": "border",
+    "--tarxiv-border-strong": "border_strong",
+    "--tarxiv-ink": "ink",
+    "--tarxiv-ink-2": "ink_2",
+    "--tarxiv-ink-3": "ink_3",
+    "--tarxiv-primary-hover": "primary_hover",
+    "--tarxiv-primary-ink": "primary_ink",
+    "--tarxiv-primary-soft": "primary_soft",
+    "--tarxiv-primary-soft-2": "primary_soft_2",
+    "--tarxiv-grid": "grid",
+    "--tarxiv-axis": "axis",
+    "--tarxiv-shadow": "shadow",
+    "--tarxiv-shadow-lg": "shadow_lg",
 }
 
-/* Tactile feedback for mobile and desktop when clicking */
-.nav-item-hover:active {
-    transform: scale(0.95);
-    transition: transform 50ms ease;
+# Older component code refers to these names; keep them pointing at the new
+# tokens so untouched pages restyle for free.
+_LEGACY_ALIASES = {
+    "--tarxiv-card-1": "card",
+    "--tarxiv-surface-1": "card_2",
+    "--tarxiv-surface-2": "card_2",
+}
+
+_STATIC_CSS = """
+/* ---------------------------------------------------------------- topbar */
+.tarxiv-wordmark {
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: -0.02em;
+    color: var(--tarxiv-ink);
+    text-decoration: none;
+    white-space: nowrap;
+}
+.tarxiv-wordmark:hover { text-decoration: none; }
+.tarxiv-wordmark .x { color: var(--tarxiv-primary-ink); }
+
+.tarxiv-topnav-link {
+    display: inline-block;
+    color: var(--tarxiv-ink-2);
+    font-weight: 500;
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: background-color 120ms ease, color 120ms ease;
+}
+.tarxiv-topnav-link:hover {
+    color: var(--tarxiv-ink);
+    background-color: var(--tarxiv-card-2);
+    text-decoration: none;
+}
+.tarxiv-topnav-link.active {
+    color: var(--tarxiv-primary-ink);
+    background-color: var(--tarxiv-primary-soft);
+}
+
+/* ------------------------------------------------------------ card head */
+.tarxiv-card-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--tarxiv-border);
 }
 
 /* Ensure long words wrap instead of clipping */
@@ -120,41 +108,42 @@ def generate_css():
     word-break: break-word;
     line-height: 1.1;
 }
-
 """
-    os.makedirs(
-        # TODO JL: Two things
-        # 1) Hardcoded path is not ideal - probably should be a config or
-        #    environment variable
-        # 2) We should probably commit this file to the repo and only regenerate
-        #    it when styles.py changes, instead of regenerating on every app
-        #    start
-        "tarxiv/dashboard/assets",
-        exist_ok=True,
-    )  # TODO: Update if dashboard moves to another repo
-    with open("tarxiv/dashboard/assets/theme.css", "w") as f:
-        f.write(light_css)
-        f.write(dark_css)
-        f.write(nav_hover)
+
+
+def _scheme_block(scheme: str) -> str:
+    """Emit the CSS custom properties for one colour scheme."""
+    tokens = COLORS[scheme]
+    lines = [
+        f"    --mantine-color-bg: {tokens['bg']};",
+        f"    --mantine-color-body: {tokens['bg']};",
+        f"    --mantine-color-text: {tokens['ink']};",
+        f"    --tarxiv-color-primary: {COLORS['primary']};",
+        f"    --tarxiv-footer-bg: {FOOTER_BG};",
+    ]
+    lines += [f"    {var}: {tokens[key]};" for var, key in _CSS_VARS.items()]
+    lines += [f"    {var}: {tokens[key]};" for var, key in _LEGACY_ALIASES.items()]
+    body = "\n".join(lines)
+    return f':root[data-mantine-color-scheme="{scheme}"] {{\n{body}\n}}\n\n'
+
+
+def generate_css():
+    """Write the themed CSS custom properties into the assets directory."""
+    assets_dir = os.path.join(os.path.dirname(__file__), os.pardir, "assets")
+    assets_dir = os.path.abspath(assets_dir)
+    os.makedirs(assets_dir, exist_ok=True)
+
+    with open(os.path.join(assets_dir, "theme.css"), "w") as f:
+        f.write("/* Generated by theme_manager.generate_css() -- do not edit. */\n\n")
+        f.write(_scheme_block("light"))
+        f.write(_scheme_block("dark"))
+        f.write(_STATIC_CSS)
     return None
 
 
-def get_theme_components() -> tuple[dict, html.Div]:
-    """Returns the Theme and the Toggle Button for the rail."""
-    return (
-        THEME,
-        # The Toggle Button (Unstyled to match your Rail)
-        html.Div(
-            create_nav_item(
-                icon="line-md:moon-to-sunny-outline-transition",
-                label="Light/Dark",
-                is_active=False,
-                id="theme-icon",
-            ),
-            id="color-scheme-toggle",
-            style={"marginTop": "auto"},  # Pushes theme toggle to the very bottom
-        ),
-    )
+def get_theme() -> dict:
+    """Returns the Mantine theme dict."""
+    return THEME
 
 
 def apply_theme(fig, theme_template):
@@ -168,53 +157,68 @@ def apply_theme(fig, theme_template):
     return fig
 
 
+def scheme_from_template(theme_template: str | None) -> str:
+    """Map a template name to a colour scheme: "dark" if it mentions dark."""
+    return "dark" if theme_template and "dark" in theme_template else "light"
+
+
+def _template_for(scheme: str) -> go.layout.Template:
+    """Build a Plotly template from the design tokens for one scheme."""
+    tokens = COLORS[scheme]
+    surface = tokens["card"]
+    axis = {
+        "gridcolor": tokens["grid"],
+        "linecolor": tokens["axis"],
+        "zerolinecolor": tokens["grid"],
+        "ticks": "outside",
+        "tickcolor": tokens["axis"],
+        "ticklen": 4,
+        "tickfont": {"size": 11, "color": tokens["ink_3"]},
+        "title": {"font": {"size": 11, "color": tokens["ink_3"]}},
+    }
+
+    template = go.layout.Template()
+    template.layout = {
+        # Match the card the figure sits on, so there is no seam.
+        "paper_bgcolor": surface,
+        "plot_bgcolor": surface,
+        "font": {"family": FONT_STACK, "size": 12, "color": tokens["ink_2"]},
+        "margin": {"l": 52, "r": 12, "t": 12, "b": 42},
+        "xaxis": axis,
+        "yaxis": axis,
+        "legend": {
+            "orientation": "h",
+            "x": 0,
+            "y": 1.02,
+            "xanchor": "left",
+            "yanchor": "bottom",
+            "font": {"size": 11.5, "color": tokens["ink_2"]},
+            "grouptitlefont": {"size": 11, "color": tokens["ink_3"]},
+            "itemsizing": "constant",
+        },
+        "hoverlabel": {
+            # Inverted plate: dark tooltip on light, light tooltip on dark.
+            "bgcolor": COLORS["dark" if scheme == "light" else "light"]["card"],
+            "font": {
+                "family": FONT_STACK,
+                "size": 12,
+                "color": COLORS["dark" if scheme == "light" else "light"]["ink"],
+            },
+            "bordercolor": "rgba(0,0,0,0)",
+        },
+        "colorway": [
+            BAND_COLORS["c"][0 if scheme == "light" else 1],
+            BAND_COLORS["o"][0 if scheme == "light" else 1],
+            BAND_COLORS["g"][0 if scheme == "light" else 1],
+            BAND_COLORS["r"][0 if scheme == "light" else 1],
+            BAND_COLORS["u"][0 if scheme == "light" else 1],
+            BAND_COLORS["z"][0 if scheme == "light" else 1],
+        ],
+    }
+    return template
+
+
 def register_tarxiv_templates():
-    # 1. Define the Dark Template
-    dark_layout = go.layout.Template()
-    dark_layout.layout = {
-        "paper_bgcolor": "#1A1B1E",  # Matches Mantine Dark Default
-        "plot_bgcolor": "#1A1B1E",
-        # "font": {"color": "#C1C2C5", "family": "Arial"},
-        "font": {"color": "#E1E2E5", "family": "Arial"},
-        "xaxis": {
-            "gridcolor": "#373A40",
-            "linecolor": "#373A40",
-            "zerolinecolor": "#373A40",
-        },
-        "yaxis": {
-            "gridcolor": "#373A40",
-            "linecolor": "#373A40",
-            "zerolinecolor": "#373A40",
-        },
-        # This is where you inject your styles.py primary color
-        # "colorway": [COLORS["primary"], "#2ecc71", "#e74c3c", "#f1c40f"],
-        "colorway": ["#4C84C6", "#27ae60", "#c0392b", "#f39c12"],
-    }
-    pio.templates["tarxiv_dark"] = dark_layout
-
-    # 2. Define the Light Template
-    light_layout = go.layout.Template()
-    light_layout.layout = {
-        "paper_bgcolor": "#FEFEFE",
-        "plot_bgcolor": "#ffffff",
-        # "font": {"color": COLORS["secondary"], "family": "Arial"},
-        "font": {"color": "#121617", "family": "Arial"},
-        "xaxis": {
-            "gridcolor": "#f1f3f5",
-            "linecolor": "#dee2e6",
-            "zerolinecolor": "#dee2e6",
-        },
-        "yaxis": {
-            "gridcolor": "#f1f3f5",
-            "linecolor": "#dee2e6",
-            "zerolinecolor": "#dee2e6",
-        },
-        # "colorway": [COLORS["primary"], "#27ae60", "#c0392b", "#f39c12"],
-        "colorway": ["#4C84C6", "#27ae60", "#c0392b", "#f39c12"],
-    }
-    pio.templates["tarxiv_light"] = light_layout
-
-
-def get_filter_style(filter_name):
-    """Returns marker color based on filter name from styles.py."""
-    return FILTER_COLORS.get(filter_name, FILTER_COLORS["Unknown"])
+    """Register the light/dark Plotly templates built from design tokens."""
+    pio.templates["tarxiv_light"] = _template_for("light")
+    pio.templates["tarxiv_dark"] = _template_for("dark")

--- a/tarxiv/dashboard/layouts/main_layout.py
+++ b/tarxiv/dashboard/layouts/main_layout.py
@@ -19,6 +19,8 @@ from ..components import (
 from ...auth import get_authenticated_user, get_jwt_from_request
 
 TOPBAR_HEIGHT_PX = 52
+# Page content sits in a centred column; matches the mockup's .container.
+CONTENT_MAX_WIDTH_PX = 1380
 
 
 def _fetch_live_profile(token):
@@ -247,6 +249,7 @@ def create_layout() -> dmc.MantineProvider:
             },
             header={"height": TOPBAR_HEIGHT_PX},
             padding="md",
+            bg="var(--tarxiv-bg)",
             children=[
                 # 1. PERMISSIONS (local): Remembers what the user said 'Yes' to.
                 dcc.Store(id="cookie-consent-store", storage_type="local"),
@@ -332,6 +335,11 @@ def create_layout() -> dmc.MantineProvider:
                                 "display": "flex",
                                 "flexDirection": "column",
                                 "minHeight": "calc(100vh - 32px)",  # Adjust 32px based on your padding
+                                # Centred content column; the topbar stays
+                                # full-bleed. Below this width it goes fluid.
+                                "maxWidth": f"{CONTENT_MAX_WIDTH_PX}px",
+                                "width": "100%",
+                                "margin": "0 auto",
                             },
                             children=[
                                 dcc.Location(

--- a/tarxiv/dashboard/layouts/main_layout.py
+++ b/tarxiv/dashboard/layouts/main_layout.py
@@ -7,15 +7,18 @@ import dash
 import flask
 import dash_mantine_components as dmc
 import requests
+from dash_extensions import Keyboard
+from dash_iconify import DashIconify
 from ..components import (
-    get_theme_components,
+    get_theme,
     footer_card,
     get_cookie_popup,
-    create_nav_link,
     avatar_fallback,
     avatar_image,
 )
 from ...auth import get_authenticated_user, get_jwt_from_request
+
+TOPBAR_HEIGHT_PX = 52
 
 
 def _fetch_live_profile(token):
@@ -53,16 +56,84 @@ SETTING_DEFAULTS = {  # These defaults need to correspond with the PERMISSION_MA
 }
 
 
+def wordmark():
+    """The "tarXiv" wordmark, linking home, with the X in brand red."""
+    return dcc.Link(
+        href="/",
+        className="tarxiv-wordmark",
+        children=[
+            "tar",
+            html.Span("X", className="x"),
+            "iv",
+        ],
+    )
+
+
+def global_search_box():
+    """Topbar object-ID search, present on every page.
+
+    Enter is captured by ``Keyboard`` and handled by the ``global_search``
+    callback in ``callbacks/style_callbacks.py``.
+    """
+    return Keyboard(
+        id="global-search-keyboard",
+        captureKeys=["Enter"],
+        n_keydowns=0,
+        children=[
+            dmc.TextInput(
+                id="global-search-input",
+                placeholder="Search object ID…",
+                size="xs",
+                w=220,
+                leftSection=DashIconify(icon="mdi:magnify", width=16),
+            )
+        ],
+    )
+
+
+def theme_toggle():
+    """Light/dark switch.
+
+    Both ids matter: ``color-scheme-toggle`` is the input of
+    ``update_active_theme`` and ``theme-icon`` is swapped by
+    ``update_all_plots_theme``.
+    """
+    return dmc.Tooltip(
+        label="Toggle light/dark theme",
+        withArrow=True,
+        children=dmc.ActionIcon(
+            DashIconify(
+                icon="line-md:moon-to-sunny-outline-transition",
+                width=18,
+                id="theme-icon",
+            ),
+            id="color-scheme-toggle",
+            variant="subtle",
+            color="gray",
+            size="lg",
+            **{"aria-label": "Toggle light/dark theme"},
+        ),
+    )
+
+
 def account_nav_hovercard(
     user_icon, user_page, account_name, account_email, account_avatar
 ):
-    """Wrap the Account nav link in a hover card showing a profile summary."""
-    nav_link = create_nav_link(
-        icon=user_icon,
-        label=user_page["name"],
-        href=user_page["relative_path"],
-        is_active=False,
-    )
+    """Wrap the account avatar in a hover card showing a profile summary."""
+    # ``user_icon`` is either an avatar component (signed in) or an icon name.
+    if isinstance(user_icon, str):
+        target = dmc.ActionIcon(
+            DashIconify(icon=user_icon, width=18),
+            variant="subtle",
+            color="gray",
+            size="lg",
+        )
+    else:
+        target = dcc.Link(
+            user_icon,
+            href=user_page["relative_path"],
+            style={"display": "flex", "alignItems": "center"},
+        )
 
     if not account_name:
         dropdown_children = [
@@ -102,18 +173,12 @@ def account_nav_hovercard(
 
     return dmc.HoverCard(
         withArrow=True,
-        position="right",
+        position="bottom-end",
         shadow="md",
         openDelay=150,
         closeDelay=500,
         children=[
-            dmc.HoverCardTarget(
-                nav_link,
-                # Here we have to pass style props to the dmc.Box wrapper using
-                # boxWrapperProps (see https://www.dash-mantine-components.com/components/hovercard
-                # and https://www.dash-mantine-components.com/style-props)
-                boxWrapperProps={"w": "100%"},
-            ),
+            dmc.HoverCardTarget(target),
             dmc.HoverCardDropdown(
                 dmc.Stack(dropdown_children, gap="xs"),
             ),
@@ -130,7 +195,7 @@ def create_layout() -> dmc.MantineProvider:
     -------
         html.Div containing the complete dashboard layout
     """
-    theme, theme_switch = get_theme_components()
+    theme = get_theme()
     user_page = dash.page_registry.get(
         "tarxiv.dashboard.pages.user",
         {
@@ -172,21 +237,16 @@ def create_layout() -> dmc.MantineProvider:
         theme=theme,
         # children=html.Div(
         children=dmc.AppShell(
+            id="app-shell",
+            # The navbar is a mobile-only drawer now that navigation lives in
+            # the header; it stays permanently collapsed on desktop.
             navbar={
-                "width": 100,
+                "width": 260,
                 "breakpoint": "sm",
-                "collapsed": {"mobile": True},
+                "collapsed": {"mobile": True, "desktop": True},
             },
-            header={
-                "height": {
-                    # "base": 50,
-                    "sm": 50,
-                },
-                "collapsed": {"mobile": False},
-            },
+            header={"height": TOPBAR_HEIGHT_PX},
             padding="md",
-            layout="alt",
-            # dmc.Box(
             children=[
                 # 1. PERMISSIONS (local): Remembers what the user said 'Yes' to.
                 dcc.Store(id="cookie-consent-store", storage_type="local"),
@@ -207,47 +267,61 @@ def create_layout() -> dmc.MantineProvider:
                     id="dummy-output", style={"display": "none"}
                 ),  # Dummy output for clientside callback
                 get_cookie_popup(),
-                # Navigation rail
+                # Top navigation bar (all breakpoints)
                 dmc.AppShellHeader(
-                    hiddenFrom="sm",
-                    children=[
-                        dmc.Burger(
-                            id="burger",
-                            opened=False,
-                            size="sm",
-                        ),
-                        dmc.Text("TarXiv Dashboard"),
-                    ],
+                    px="md",
+                    style={
+                        "backgroundColor": "var(--tarxiv-card)",
+                        "borderBottom": "1px solid var(--tarxiv-border)",
+                    },
+                    children=dmc.Group(
+                        h=TOPBAR_HEIGHT_PX,
+                        gap="sm",
+                        wrap="nowrap",
+                        align="center",
+                        children=[
+                            dmc.Burger(
+                                id="burger",
+                                opened=False,
+                                size="sm",
+                                hiddenFrom="sm",
+                            ),
+                            wordmark(),
+                            # Nav links (populated by refresh_navigation).
+                            # dmc.Box, not html.Div: visibleFrom is a Mantine
+                            # style prop and the html.* components reject it.
+                            dmc.Box(id="topbar-nav", visibleFrom="sm"),
+                            dmc.Box(style={"flex": 1}),
+                            dmc.Box(global_search_box(), visibleFrom="md"),
+                            theme_toggle(),
+                            account_nav_hovercard(
+                                user_icon=user_icon,
+                                user_page=user_page,
+                                account_name=account_name,
+                                account_email=account_email,
+                                account_avatar=account_avatar,
+                            ),
+                        ],
+                    ),
                 ),
+                # Mobile navigation drawer. Nav clicks reload the page (the
+                # url Location has refresh=True), so it resets closed by itself.
                 dmc.AppShellNavbar(
-                    p="xs",
-                    style={"backgroundColor": "var(--tarxiv-surface-1)"},
-                    children=[
-                        dmc.Stack(
-                            h="100%",
-                            gap="xs",
-                            children=[
-                                # The main navigation items (populated by callback)
-                                html.Div(id="nav-rail-content"),
-                                # The "Magic" bottom pin
-                                html.Div(
-                                    children=[
-                                        account_nav_hovercard(
-                                            user_icon=user_icon,
-                                            user_page=user_page,
-                                            account_name=account_name,
-                                            account_email=account_email,
-                                            account_avatar=account_avatar,
-                                        ),
-                                        theme_switch,
-                                    ],
-                                    style={
-                                        "marginTop": "auto"
-                                    },  # Pushes theme toggle to the very bottom
+                    p="md",
+                    children=dmc.Stack(
+                        gap="xs",
+                        children=[
+                            html.Div(id="mobile-nav-content"),
+                            dmc.NavLink(
+                                label=user_page["name"],
+                                href=user_page["relative_path"],
+                                leftSection=DashIconify(
+                                    icon=user_page.get("icon", "mdi:user-outline"),
+                                    width=20,
                                 ),
-                            ],
-                        )
-                    ],
+                            ),
+                        ],
+                    ),
                 ),
                 # Content container
                 dmc.AppShellMain(

--- a/tarxiv/dashboard/pages/alerts.py
+++ b/tarxiv/dashboard/pages/alerts.py
@@ -18,10 +18,7 @@ from ..components import (
     create_message_banner,
 )
 
-from ...auth import (
-    get_authenticated_user,
-    get_jwt_from_request,
-)
+from ...auth import get_jwt_from_request
 import requests
 # from pydantic import ValidationError
 
@@ -37,33 +34,25 @@ dash.register_page(
 
 
 def layout(**kwargs):
-    # perform search if id is provided in URL, otherwise show empty search page
-    token = get_jwt_from_request(request)
-    user = get_authenticated_user(jwt_token=token)
-
-    print(f"User: {user}")
-
-    page_contents = create_message_banner("Please log in to view alerts.", "warning")
-    if user:
-        # User came via deep link and has a saved session
-        page_contents = (
-            expressive_card(
-                title="Alerts",
-                children=[
-                    dmc.Box(
-                        id="alerts-table-body",
+    # Alerts are public: no login needed to browse them.
+    page_contents = (
+        expressive_card(
+            title="Alerts",
+            children=[
+                dmc.Box(
+                    id="alerts-table-body",
+                ),
+                dmc.Center(
+                    dmc.Pagination(
+                        id="alerts-pagination",
+                        total=20,
+                        siblings=2,
+                        value=1,
                     ),
-                    dmc.Center(
-                        dmc.Pagination(
-                            id="alerts-pagination",
-                            total=20,
-                            siblings=2,
-                            value=1,
-                        ),
-                    ),
-                ],
-            ),
-        )
+                ),
+            ],
+        ),
+    )
 
     return dmc.Stack(
         children=[
@@ -100,9 +89,6 @@ def update_alerts_table(page_number):
         token=token,
         logger=current_app.config["TXV_LOGGER"],
     )
-
-    if response.status_code == 401:
-        return create_message_banner("Session expired. Please log in again.", "warning")
 
     if response.status_code != 200:
         return create_message_banner(

--- a/tarxiv/dashboard/pages/cone.py
+++ b/tarxiv/dashboard/pages/cone.py
@@ -1,5 +1,6 @@
 import os
 from typing import cast
+from urllib.parse import parse_qs, urlencode
 
 import dash
 from dash import (
@@ -43,6 +44,85 @@ dash.register_page(
 )
 
 
+# A cone search is fully described by three numbers, so the query string is the
+# page's source of truth: pressing Search writes ?ra=&dec=&radius= to the
+# page-local Location, and that write is what actually runs the search. All
+# three input options normalise to decimal degrees first, so every search — no
+# matter which box it was typed into — produces the same shareable URL.
+CONE_QUERY_KEYS = ("ra", "dec", "radius")
+
+
+def build_cone_query_string(ra: float, dec: float, radius: float) -> str:
+    """Build the '?ra=...&dec=...&radius=...' search string for a cone search."""
+    return "?" + urlencode({
+        "ra": f"{float(ra):.6f}",
+        "dec": f"{float(dec):.6f}",
+        "radius": f"{float(radius):g}",
+    })
+
+
+def parse_cone_query_params(params: dict) -> tuple[float, float, float] | None:
+    """Parse cone-search query parameters into (ra, dec, radius).
+
+    Args:
+        params: Flattened query parameters, i.e. ``{key: str}``. Dash pages
+            hands ``layout()`` exactly this shape; callbacks reading a raw
+            search string should use :func:`parse_cone_search_string`.
+
+    Returns
+    -------
+        ``(ra_deg, dec_deg, radius_arcsec)``, or ``None`` when none of the
+        three parameters are present.
+
+    Raises
+    ------
+        ValueError: with a user-facing message when the parameters are present
+        but incomplete, non-numeric, or outside the bounds accepted by the
+        search form.
+    """
+    present = {key: params.get(key) for key in CONE_QUERY_KEYS}
+    if all(value is None or str(value).strip() == "" for value in present.values()):
+        return None
+
+    missing = [
+        key
+        for key, value in present.items()
+        if value is None or str(value).strip() == ""
+    ]
+    if missing:
+        raise ValueError(
+            f"Incomplete cone search link: missing {', '.join(missing)}. "
+            "A link needs ra, dec and radius."
+        )
+
+    try:
+        ra = float(cast(str, present["ra"]))
+        dec = float(cast(str, present["dec"]))
+        radius = float(cast(str, present["radius"]))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "Could not read the coordinates from the link. ra, dec and radius "
+            "must all be numbers, e.g. /cone?ra=315.403750&dec=68.163333&radius=30."
+        ) from exc
+
+    if not 0 <= ra <= 360:
+        raise ValueError(f"RA must be between 0 and 360 degrees (got {ra}).")
+    if not -90 <= dec <= 90:
+        raise ValueError(f"Dec must be between -90 and 90 degrees (got {dec}).")
+    if radius <= 0:
+        raise ValueError(f"Radius must be greater than zero (got {radius}).")
+
+    return ra, dec, radius
+
+
+def parse_cone_search_string(search: str) -> tuple[float, float, float] | None:
+    """Parse a raw '?ra=...&dec=...' Location search string into coordinates."""
+    if not search:
+        return None
+    parsed = parse_qs(search.lstrip("?"))
+    return parse_cone_query_params({key: values[0] for key, values in parsed.items()})
+
+
 # Initialise the Aladin Lite widget for the cone-search results: centre on the
 # search position, draw the search radius as a subtle ring, drop a marker per
 # result, and hook up hover-linking from result cards to marker highlights.
@@ -72,14 +152,52 @@ def update_cone_results_page(page, store_data):
     return build_cone_result_cards_page(store_data["results"], page)
 
 
-def layout(**kwargs):
-    # logger = current_app.config["TXV_LOGGER"]
+def layout(ra=None, dec=None, radius=None, **kwargs):
+    """Build the cone-search page, running the search when the URL carries one.
 
-    # token = get_jwt_from_request(request)
+    A pasted or bookmarked ``/cone?ra=&dec=&radius=`` link is a cold page load,
+    so the search has to happen here rather than in the URL callback — Dash
+    forbids ``allow_duplicate`` outputs on a callback that fires on initial
+    call, and the banner/settings stores are shared with other callbacks. This
+    mirrors ``pages/lightcurve.py``, which runs its search in ``layout()`` for
+    the same reason. In-session searches go through ``run_cone_search`` below;
+    both paths call :func:`render_cone_search`, so the logic lives in one place.
+    """
+    logger = current_app.config["TXV_LOGGER"]
+
+    results, status, banner, store_data = html.Div(), "", [], None
+
+    try:
+        coordinates = parse_cone_query_params({
+            "ra": ra,
+            "dec": dec,
+            "radius": radius,
+        })
+    except ValueError as exc:
+        coordinates = None
+        banner = create_message_banner(str(exc), "warning")
+
+    if coordinates:
+        ra, dec, radius = coordinates
+        token = get_jwt_from_request(request)
+        auth_banner = cone_auth_banner(token)
+        if auth_banner is not None:
+            banner = auth_banner
+        else:
+            results, status, banner, store_data = render_cone_search(
+                ra, dec, radius, token, logger
+            )
+    else:
+        # Nothing usable in the URL: leave the inputs empty as before.
+        ra, dec, radius = None, None, None
 
     return dmc.Stack(
         children=[
-            dcc.Store(id="cone-search-store"),
+            dcc.Store(id="cone-search-store", data=store_data),
+            # Page-local, refresh=False: writing to this pushes history without
+            # reloading the page. The app-wide "url" and "auth-location"
+            # Locations are both refresh=True and would force a full reload.
+            dcc.Location(id="cone-url", refresh=False),
             title_card(
                 title_text="TarXiv Database Explorer",
                 subtitle_text="Explore astronomical transients and their lightcurves",
@@ -100,6 +218,7 @@ def layout(**kwargs):
                                     dmc.NumberInput(
                                         id="ra-input",
                                         placeholder="0-360",
+                                        value=ra,
                                         min=0,
                                         max=360,
                                         label="RA (degrees):",
@@ -110,6 +229,7 @@ def layout(**kwargs):
                                     dmc.NumberInput(
                                         id="dec-input",
                                         placeholder="-90 to 90",
+                                        value=dec,
                                         min=-90,
                                         max=90,
                                         label="Dec (degrees):",
@@ -120,7 +240,7 @@ def layout(**kwargs):
                                     dmc.NumberInput(
                                         id="radius-input",
                                         placeholder=">0",
-                                        # value=30,
+                                        value=radius,
                                         min=0,
                                         label="Radius (arcsec):",
                                         style={
@@ -225,7 +345,7 @@ def layout(**kwargs):
             ),
             dmc.Box(
                 id="message-banner",
-                children=[],
+                children=banner,
                 style={"marginBottom": "20px"},
             ),
             dmc.Stack(
@@ -237,11 +357,11 @@ def layout(**kwargs):
                             "fontStyle": "italic",
                             "fontSize": "14px",
                         },
-                        # children=status,
+                        children=status,
                     ),
                     dmc.Stack(
                         id="results-container",
-                        # children=[res],
+                        children=results,
                     ),
                 ],
             ),
@@ -298,13 +418,75 @@ def parse_combined_coordinates(combined: str) -> tuple[float, float]:
     return parse_hms_dms_coordinates(ra_hms, dec_dms)
 
 
+def cone_auth_banner(token):
+    """Return a banner explaining why `token` cannot be used, or None if it can."""
+    validation = validate_token(token)
+
+    if validation["status"] == TokenStatus.EXPIRED:
+        return create_message_banner(
+            "Your session has expired. Please log in again.", "warning"
+        )
+    elif validation["status"] == TokenStatus.INVALID and token:
+        return create_message_banner(
+            "Invalid authentication token. Please log in again.", "error"
+        )
+    elif not token or validation["status"] != TokenStatus.VALID:
+        return create_message_banner("Please log in to perform the search.", "warning")
+
+    return None
+
+
+def render_cone_search(ra, dec, radius, token, logger):
+    """Run a cone search and build everything the page needs to show it.
+
+    Returns
+    -------
+        ``(results_children, status_text, banner, store_data)``. ``store_data``
+        is None when the search failed, so the caller can leave the existing
+        store untouched.
+    """
+    status_msg = f"Cone search: RA={ra}, Dec={dec}, radius={radius} arcsec"
+    logger.info({
+        "search_type": "cone",
+        "ra": ra,
+        "dec": dec,
+        "radius": radius,
+    })
+
+    try:
+        results = get_cone_search_results(ra, dec, radius, token, logger)
+
+        result = format_cone_search_results(results, ra, dec)
+        success_banner = create_message_banner(
+            f"Found {len(results)} object(s) in search region", "success"
+        )
+        logger.info({"info": f"Cone search found {len(results)} objects."})
+
+        store_data = {
+            "results": results,
+            "ra": ra,
+            "dec": dec,
+            "radius": radius,
+        }
+
+        return result, status_msg, success_banner, store_data
+    except Unauthorized as e:
+        logger.warning({"warning": f"Unauthorized cone search attempt: {str(e)}"})
+        error_banner = create_message_banner(
+            "Unauthorized: Invalid API token. Check your token.", "error"
+        )
+        return html.Div(), "Unauthorized", error_banner, None
+    except Exception as e:
+        error_msg = f"Error: {str(e)}"
+        logger.error({"error": error_msg})
+        error_banner = create_message_banner(error_msg, "error")
+        return html.Div(), "Error occurred", error_banner, None
+
+
 @callback(
     [
-        Output("results-container", "children", allow_duplicate=True),
-        Output("search-status", "children", allow_duplicate=True),
+        Output("cone-url", "search", allow_duplicate=True),
         Output("message-banner", "children", allow_duplicate=True),
-        Output("cone-search-store", "data"),
-        Output("active-settings-store", "data", allow_duplicate=True),
     ],
     [
         Input("cone-search-button", "n_clicks"),
@@ -323,11 +505,10 @@ def parse_combined_coordinates(combined: str) -> tuple[float, float]:
         State("radius-hmsdms-input", "value"),
         State("radec-combined-input", "value"),
         State("radius-combined-input", "value"),
-        State("active-settings-store", "data"),
     ],
     prevent_initial_call=True,
 )
-def handle_cone_search(
+def submit_cone_search(
     n_clicks,
     n_keydowns,
     n_hmsdms_clicks,
@@ -342,35 +523,15 @@ def handle_cone_search(
     radius_hmsdms,
     radec_combined,
     radius_combined,
-    settings,
 ):
-    """Handle cone search button clicks."""
-    logger = current_app.config["TXV_LOGGER"]
+    """Validate the search form and push the coordinates into the URL.
 
-    token = get_jwt_from_request(request)
-    validation = validate_token(token)
-
-    if validation["status"] == TokenStatus.EXPIRED:
-        warning_banner = create_message_banner(
-            "Your session has expired. Please log in again.", "warning"
-        )
-        return html.Div(), "", warning_banner, no_update, no_update
-    elif validation["status"] == TokenStatus.INVALID and token:
-        warning_banner = create_message_banner(
-            "Invalid authentication token. Please log in again.", "error"
-        )
-        return html.Div(), "", warning_banner, no_update, no_update
-    elif not token or validation["status"] != TokenStatus.VALID:
-        warning_banner = create_message_banner(
-            "Please log in to perform the search.", "warning"
-        )
-        return html.Div(), "", warning_banner, no_update, no_update
-
-    if not isinstance(settings, dict):
-        settings = {}
-
-    settings.update({"tarxiv_user_token": token})  # Save token to active settings
-
+    This does not run the search itself: it normalises whichever input option
+    was used down to decimal degrees and writes the resulting query string to
+    the page-local Location, which is what triggers `run_cone_search`. Doing it
+    this way means a search performed in the browser and a search arriving via
+    a pasted link travel exactly the same path.
+    """
     trigger_id = ctx.triggered_id
     use_hmsdms_input = trigger_id in {
         "cone-search-hmsdms-button",
@@ -386,18 +547,18 @@ def handle_cone_search(
             warning_banner = create_message_banner(
                 "Please provide a combined RA/Dec coordinate string.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
         if radius_combined is None or radius_combined <= 0:
             warning_banner = create_message_banner(
                 "Please provide a radius greater than zero.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
 
         try:
             ra, dec = parse_combined_coordinates(radec_combined)
         except ValueError as exc:
             warning_banner = create_message_banner(str(exc), "warning")
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
 
         radius = float(radius_combined)
     elif use_hmsdms_input:
@@ -410,18 +571,18 @@ def handle_cone_search(
             warning_banner = create_message_banner(
                 "Please provide both RA (HMS) and Dec (DMS) coordinates.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
         if radius_hmsdms is None or radius_hmsdms <= 0:
             warning_banner = create_message_banner(
                 "Please provide a radius greater than zero.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
 
         try:
             ra, dec = parse_hms_dms_coordinates(ra_hms, dec_dms)
         except ValueError as exc:
             warning_banner = create_message_banner(str(exc), "warning")
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
 
         radius = float(radius_hmsdms)
     else:
@@ -429,50 +590,69 @@ def handle_cone_search(
             warning_banner = create_message_banner(
                 "Please provide valid RA, Dec and radius coordinates.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
         if radius <= 0:
             warning_banner = create_message_banner(
                 "Please provide a radius greater than zero.", "warning"
             )
-            return html.Div(), "", warning_banner, no_update, no_update
+            return no_update, warning_banner
 
-    status_msg = f"Cone search: RA={ra}, Dec={dec}, radius={radius} arcsec"
-    logger.info({
-        "search_type": "cone",
-        "ra": ra,
-        "dec": dec,
-        "radius": radius,
-    })
+    return build_cone_query_string(ra, dec, radius), []
+
+
+@callback(
+    [
+        Output("results-container", "children", allow_duplicate=True),
+        Output("search-status", "children", allow_duplicate=True),
+        Output("message-banner", "children", allow_duplicate=True),
+        Output("cone-search-store", "data", allow_duplicate=True),
+        Output("active-settings-store", "data", allow_duplicate=True),
+    ],
+    Input("cone-url", "search"),
+    State("active-settings-store", "data"),
+    prevent_initial_call=True,
+)
+def run_cone_search(search, settings):
+    """Run the cone search described by the current query string.
+
+    Fires when `submit_cone_search` writes a new query string, and when the
+    user walks the history with the browser's back/forward buttons. Cold loads
+    are handled by `layout()` instead — see its docstring.
+    """
+    logger = current_app.config["TXV_LOGGER"]
+
     try:
-        # Perform cone search
-        results = get_cone_search_results(ra, dec, radius, token, logger)
+        coordinates = parse_cone_search_string(search)
+    except ValueError as exc:
+        warning_banner = create_message_banner(str(exc), "warning")
+        return html.Div(), "", warning_banner, no_update, no_update
 
-        # Display results
-        result = format_cone_search_results(results, ra, dec)
-        success_banner = create_message_banner(
-            f"Found {len(results)} object(s) in search region", "success"
-        )
-        logger.info({"info": f"Cone search found {len(results)} objects."})
+    if not coordinates:
+        return no_update, no_update, no_update, no_update, no_update
 
-        store_data = {
-            "results": results,
-            "ra": ra,
-            "dec": dec,
-            "radius": radius,
-        }
+    ra, dec, radius = coordinates
 
-        return result, status_msg, success_banner, store_data, settings
-    except Unauthorized as e:
-        logger.warning({"warning": f"Unauthorized cone search attempt: {str(e)}"})
-        error_banner = create_message_banner(
-            "Unauthorized: Invalid API token. Check your token.", "error"
-        )
-        return html.Div(), "Unauthorized", error_banner, no_update, no_update
-    except Exception as e:
-        error_msg = f"Error: {str(e)}"
-        logger.error({"error": error_msg})
-        error_banner = create_message_banner(error_msg, "error")
-        return html.Div(), "Error occurred", error_banner, no_update, no_update
+    token = get_jwt_from_request(request)
+    auth_banner = cone_auth_banner(token)
+    if auth_banner is not None:
+        return html.Div(), "", auth_banner, no_update, no_update
+
+    if not isinstance(settings, dict):
+        settings = {}
+
+    settings.update({"tarxiv_user_token": token})  # Save token to active settings
+
+    results, status_msg, banner, store_data = render_cone_search(
+        ra, dec, radius, token, logger
+    )
+
+    return (
+        results,
+        status_msg,
+        banner,
+        store_data if store_data is not None else no_update,
+        settings,
+    )
 
 
 def get_cone_search_results(ra, dec, radius, token, logger) -> list:

--- a/tarxiv/dashboard/pages/cone.py
+++ b/tarxiv/dashboard/pages/cone.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 from flask import current_app, request
 from werkzeug.exceptions import Unauthorized
 
-from ...auth import get_jwt_from_request, validate_token, TokenStatus
+from ...auth import get_jwt_from_request
 from ..components import (
     title_card,
     expressive_card,
@@ -180,13 +180,9 @@ def layout(ra=None, dec=None, radius=None, **kwargs):
     if coordinates:
         ra, dec, radius = coordinates
         token = get_jwt_from_request(request)
-        auth_banner = cone_auth_banner(token)
-        if auth_banner is not None:
-            banner = auth_banner
-        else:
-            results, status, banner, store_data = render_cone_search(
-                ra, dec, radius, token, logger
-            )
+        results, status, banner, store_data = render_cone_search(
+            ra, dec, radius, token, logger
+        )
     else:
         # Nothing usable in the URL: leave the inputs empty as before.
         ra, dec, radius = None, None, None
@@ -418,24 +414,6 @@ def parse_combined_coordinates(combined: str) -> tuple[float, float]:
     return parse_hms_dms_coordinates(ra_hms, dec_dms)
 
 
-def cone_auth_banner(token):
-    """Return a banner explaining why `token` cannot be used, or None if it can."""
-    validation = validate_token(token)
-
-    if validation["status"] == TokenStatus.EXPIRED:
-        return create_message_banner(
-            "Your session has expired. Please log in again.", "warning"
-        )
-    elif validation["status"] == TokenStatus.INVALID and token:
-        return create_message_banner(
-            "Invalid authentication token. Please log in again.", "error"
-        )
-    elif not token or validation["status"] != TokenStatus.VALID:
-        return create_message_banner("Please log in to perform the search.", "warning")
-
-    return None
-
-
 def render_cone_search(ra, dec, radius, token, logger):
     """Run a cone search and build everything the page needs to show it.
 
@@ -633,9 +611,6 @@ def run_cone_search(search, settings):
     ra, dec, radius = coordinates
 
     token = get_jwt_from_request(request)
-    auth_banner = cone_auth_banner(token)
-    if auth_banner is not None:
-        return html.Div(), "", auth_banner, no_update, no_update
 
     if not isinstance(settings, dict):
         settings = {}

--- a/tarxiv/dashboard/pages/lightcurve.py
+++ b/tarxiv/dashboard/pages/lightcurve.py
@@ -27,7 +27,6 @@ from ...dto import (
     MetadataResponseModel,
 )
 from ...auth import (
-    get_authenticated_user,
     get_jwt_from_request,
     validate_token,
     TokenStatus,
@@ -52,10 +51,9 @@ def layout(id=None, **kwargs):
     logger = current_app.config["TXV_LOGGER"]
 
     token = get_jwt_from_request(request)
-    user = get_authenticated_user(jwt_token=token)
 
-    if id and user:
-        # User came via deep link and has a saved session
+    if id:
+        # Deep link to an object: searching is public, so no login needed.
         (
             results_top,
             metadata_card,
@@ -66,32 +64,6 @@ def layout(id=None, **kwargs):
             lc_store,
             aladin_store,
         ) = perform_search(id, token, logger)
-    elif id and not user:
-        validation = validate_token(token)
-
-        # Deep link but no token: show the search card pre-filled with the ID
-        # but warn the user that a token is missing.
-        results_top = build_empty_search_state(prefill=id)
-        metadata_card, citations_card, full_metadata = (
-            html.Div(),
-            html.Div(),
-            html.Div(),
-        )
-        status = "Authentication required"
-
-        if validation["status"] == TokenStatus.EXPIRED:
-            banner = create_message_banner(
-                "Your session has expired. Please log in again.", "warning"
-            )
-        elif validation["status"] == TokenStatus.INVALID and token:
-            banner = create_message_banner(
-                "Invalid authentication token. Please log in again.", "error"
-            )
-        else:
-            banner = create_message_banner("Please log in to view data.", "warning")
-
-        lc_store = None
-        aladin_store = None
     else:
         # Default empty search page
         results_top = build_empty_search_state()

--- a/tarxiv/dashboard/pages/lightcurve.py
+++ b/tarxiv/dashboard/pages/lightcurve.py
@@ -11,13 +11,16 @@ from dash.dependencies import Input, Output, State
 from flask import current_app, request
 from werkzeug.exceptions import Unauthorized
 import dash_mantine_components as dmc
+from dash_iconify import DashIconify
 from ..components import (
     expressive_card,
     format_object_metadata,
     create_message_banner,
     build_empty_search_state,
     build_photometry_table,
+    build_tag_chips,
     scheme_from_template,
+    tag_badge,
 )
 from ...dto import (
     LightcurveResponseModel,
@@ -181,6 +184,16 @@ clientside_callback(
     ClientsideFunction(namespace="lightcurve_aladin", function_name="initialize"),
     Output("aladin-status-dummy", "children"),
     Input("lightcurve-aladin-store", "data"),
+)
+
+
+# "Tag" in the page head jumps to the tag card and focuses its select, so the
+# card stays the single place tags are managed. See assets/object_page.js.
+clientside_callback(
+    ClientsideFunction(namespace="object_page", function_name="scrollToTags"),
+    Output("tag-scroll-dummy", "children"),
+    Input("jump-to-tags", "n_clicks"),
+    prevent_initial_call=True,
 )
 
 
@@ -368,70 +381,72 @@ def render_tagging_panel(object_id, visible_tags, assigned_tags):
         if tag["id"] not in assigned_tag_ids
     ]
 
-    assigned_blocks = (
-        [
-            dmc.Paper(
-                withBorder=True,
-                p="sm",
-                radius="md",
-                children=dmc.Group(
-                    [
-                        dmc.Group(
-                            [
-                                dmc.Badge(
-                                    item["tag"]["name"],
-                                    color=(item["tag"].get("color") or "gray").lstrip(
-                                        "#"
-                                    ),
-                                    variant="light",
-                                ),
-                                dmc.Text(
-                                    item["owner_type"].capitalize(),
-                                    size="sm",
-                                    c="dimmed",
-                                ),
-                            ],
-                            gap="xs",
-                        ),
-                        dmc.Button(
-                            "Remove",
-                            id={
-                                "type": "remove-object-tag",
-                                "assignment_id": item["id"],
-                            },
-                            n_clicks=0,
-                            variant="subtle",
-                            color="red",
-                        ),
-                    ],
-                    justify="space-between",
-                ),
+    # Assigned tags read as a compact wrapping row of chips above the assign
+    # controls, rather than a stack of full-width rows.
+    if assigned_tags:
+        assigned_chips = [
+            dmc.Group(
+                [
+                    tag_badge(item["tag"], size="sm"),
+                    dmc.ActionIcon(
+                        DashIconify(icon="mdi:close", width=12),
+                        id={
+                            "type": "remove-object-tag",
+                            "assignment_id": item["id"],
+                        },
+                        n_clicks=0,
+                        variant="subtle",
+                        color="gray",
+                        size="xs",
+                        # dmc.ActionIcon 2.6.0 has no `title` prop.
+                        **{
+                            "aria-label": (
+                                f"Remove {item['tag'].get('name', 'tag')} "
+                                f"({item['owner_type']})"
+                            )
+                        },
+                    ),
+                ],
+                gap=2,
+                wrap="nowrap",
+                align="center",
             )
             for item in assigned_tags
         ]
-        if assigned_tags
-        else [dmc.Text("No tags assigned to this object.", c="dimmed")]
-    )
+    else:
+        assigned_chips = [
+            dmc.Text("No tags assigned to this object.", size="xs", c="dimmed")
+        ]
 
     return expressive_card(
-        title=f"Object Tags: {object_id}",
+        id="object-tag-card",
+        title="Tags",
+        icon="mdi:tag-outline",
         children=[
-            dmc.Text(
-                "Assign any tag available to you, including personal tags and team tags from your memberships.",
-                c="dimmed",
-            ),
-            dmc.Group([
-                dmc.Select(
-                    id="assign-object-tag-select",
-                    placeholder="Choose a tag",
-                    data=available_options,
-                    value=None,
-                    style={"minWidth": "320px"},
-                ),
-                dmc.Button("Assign tag", id="assign-object-tag-button", n_clicks=0),
-            ]),
+            dmc.Group(id="object-tagging-list", children=assigned_chips, gap="xs"),
             html.Div(id="object-tagging-banner"),
-            dmc.Stack(id="object-tagging-list", children=assigned_blocks),
+            dmc.Group(
+                [
+                    dmc.Select(
+                        id="assign-object-tag-select",
+                        placeholder="Choose a tag",
+                        data=available_options,
+                        value=None,
+                        size="xs",
+                        searchable=True,
+                        style={"flex": 1, "minWidth": 0},
+                    ),
+                    dmc.Button(
+                        "Assign",
+                        id="assign-object-tag-button",
+                        n_clicks=0,
+                        size="xs",
+                        variant="default",
+                    ),
+                ],
+                gap="xs",
+                wrap="nowrap",
+            ),
         ],
     )
 
@@ -622,12 +637,21 @@ def perform_search(object_id, token, logger):
         list((meta.get("data_sources") or {}).keys()), token, logger
     )
 
+    # Assigned tags, so the head chips are correct on first paint rather than
+    # popping in once the tagging callback lands.
+    assigned_tags = []
+    tags_response = fetch_object_tags(object_id, token, logger)
+    if tags_response is not None and tags_response.status_code == 200:
+        assigned_tags = tags_response.json()
+
     # Display metadata
     results_top, metadata_card, citations_card, full_metadata = format_object_metadata(
-        object_id, meta, citation_str, lc_data=lc_data, logger=logger
-    )
-    success_banner = create_message_banner(
-        f"Successfully loaded object: {object_id}", "success"
+        object_id,
+        meta,
+        citation_str,
+        lc_data=lc_data,
+        assigned_tags=assigned_tags,
+        logger=logger,
     )
     logger.info({"info": f"Object {object_id} loaded successfully."})
 
@@ -646,8 +670,10 @@ def perform_search(object_id, token, logger):
         metadata_card,
         citations_card,
         full_metadata,
-        status_msg,
-        success_banner,
+        # A successful load needs no announcement -- the page itself is the
+        # feedback. Both the status line and the banner slot stay empty.
+        "",
+        html.Div(),
         lc_store,
         aladin_store,
     )
@@ -702,6 +728,9 @@ def load_object_tagging_panel(lightcurve_store):
         Output("object-tagging-container", "children", allow_duplicate=True),
         Output("lightcurve-object-tags-store", "data", allow_duplicate=True),
         Output("assign-object-tag-select", "value"),
+        # Safe to target here (unlike in load_object_tagging_panel): assigning
+        # requires a loaded object, so the page head always exists.
+        Output("object-tag-chips", "children", allow_duplicate=True),
     ],
     Input("assign-object-tag-button", "n_clicks"),
     [
@@ -713,32 +742,39 @@ def load_object_tagging_panel(lightcurve_store):
 )
 def handle_assign_object_tag(n_clicks, tag_id, lightcurve_store, visible_tags):
     if not n_clicks or not lightcurve_store or not tag_id:
-        return no_update, no_update, no_update
+        return no_update, no_update, no_update, no_update
 
     object_id = lightcurve_store.get("id")
     logger = current_app.config["TXV_LOGGER"]
     token = get_jwt_from_request(request)
     response = assign_object_tag(object_id, tag_id, token, logger)
-    if response.status_code != 201:
-        assigned_tags = fetch_object_tags(object_id, token, logger)
-        current_assignments = (
-            assigned_tags.json() if assigned_tags.status_code == 200 else []
-        )
-        panel = render_tagging_panel(object_id, visible_tags or [], current_assignments)
-        return panel, current_assignments, no_update
 
     updated_response = fetch_object_tags(object_id, token, logger)
     updated_assignments = (
         updated_response.json() if updated_response.status_code == 200 else []
     )
     panel = render_tagging_panel(object_id, visible_tags or [], updated_assignments)
-    return panel, updated_assignments, None
+    chips = build_tag_chips(updated_assignments)
+
+    if response.status_code != 201:
+        # Surface the failure rather than silently re-rendering an unchanged
+        # panel, which used to look like the click did nothing.
+        logger.warning({
+            "warning": (
+                f"Failed to assign tag {tag_id} to {object_id}: "
+                f"status {response.status_code}"
+            )
+        })
+        return panel, updated_assignments, no_update, chips
+
+    return panel, updated_assignments, None, chips
 
 
 @callback(
     [
         Output("object-tagging-container", "children", allow_duplicate=True),
         Output("lightcurve-object-tags-store", "data", allow_duplicate=True),
+        Output("object-tag-chips", "children", allow_duplicate=True),
     ],
     Input({"type": "remove-object-tag", "assignment_id": dash.ALL}, "n_clicks"),
     [
@@ -750,11 +786,11 @@ def handle_assign_object_tag(n_clicks, tag_id, lightcurve_store, visible_tags):
 )
 def handle_remove_object_tag(n_clicks, button_ids, lightcurve_store, visible_tags):
     if not lightcurve_store or not any(n_clicks or []):
-        return no_update, no_update
+        return no_update, no_update, no_update
 
     triggered = dash.ctx.triggered_id
     if not triggered:
-        return no_update, no_update
+        return no_update, no_update, no_update
 
     object_id = lightcurve_store.get("id")
     assignment_id = triggered.get("assignment_id")
@@ -767,4 +803,4 @@ def handle_remove_object_tag(n_clicks, button_ids, lightcurve_store, visible_tag
         updated_response.json() if updated_response.status_code == 200 else []
     )
     panel = render_tagging_panel(object_id, visible_tags or [], updated_assignments)
-    return panel, updated_assignments
+    return panel, updated_assignments, build_tag_chips(updated_assignments)

--- a/tarxiv/dashboard/pages/lightcurve.py
+++ b/tarxiv/dashboard/pages/lightcurve.py
@@ -1,15 +1,23 @@
 import dash
-from dash import html, callback, no_update, dcc, clientside_callback
+from dash import (
+    ClientsideFunction,
+    html,
+    callback,
+    no_update,
+    dcc,
+    clientside_callback,
+)
 from dash.dependencies import Input, Output, State
-from dash_extensions import Keyboard
 from flask import current_app, request
 from werkzeug.exceptions import Unauthorized
 import dash_mantine_components as dmc
 from ..components import (
-    title_card,
     expressive_card,
     format_object_metadata,
     create_message_banner,
+    build_empty_search_state,
+    build_photometry_table,
+    scheme_from_template,
 )
 from ...dto import (
     LightcurveResponseModel,
@@ -47,6 +55,7 @@ def layout(id=None, **kwargs):
         # User came via deep link and has a saved session
         (
             results_top,
+            metadata_card,
             citations_card,
             full_metadata,
             status,
@@ -57,9 +66,10 @@ def layout(id=None, **kwargs):
     elif id and not user:
         validation = validate_token(token)
 
-        # Deep link but no token: Show the search bar pre-filled with ID
+        # Deep link but no token: show the search card pre-filled with the ID
         # but warn the user that a token is missing.
-        results_top, citations_card, full_metadata = (
+        results_top = build_empty_search_state(prefill=id)
+        metadata_card, citations_card, full_metadata = (
             html.Div(),
             html.Div(),
             html.Div(),
@@ -81,7 +91,8 @@ def layout(id=None, **kwargs):
         aladin_store = None
     else:
         # Default empty search page
-        results_top, citations_card, full_metadata, status, banner = (
+        results_top = build_empty_search_state()
+        metadata_card, citations_card, full_metadata, status, banner = (
             html.Div(),
             html.Div(),
             html.Div(),
@@ -104,83 +115,44 @@ def layout(id=None, **kwargs):
                 storage_type="memory",
                 data=aladin_store,
             ),
-            title_card(
-                title_text="TarXiv Database Explorer",
-                subtitle_text="Explore astronomical transients and their lightcurves",
+            dmc.Box(id="message-banner", children=[banner]),
+            dmc.Text(
+                id="search-status",
+                children=status,
+                size="xs",
+                c="dimmed",
+                fs="italic",
             ),
-            expressive_card(
-                title="Lightcurve Search",
-                children=[
-                    dmc.Stack([
-                        dmc.Text(
-                            "Enter a TNS object name to view its metadata and lightcurve",
-                        ),
-                        dmc.Group(
-                            [
-                                Keyboard(
-                                    children=[
-                                        dmc.TextInput(
-                                            id="object-id-input",
-                                            placeholder="Enter object ID (e.g., 2024abc)",
-                                            value=id,  # Pre-populate with URL parameter
-                                            style={
-                                                "width": "400px",
-                                                "marginRight": "10px",
-                                            },
-                                        ),
-                                    ],
-                                    captureKeys=["Enter"],
-                                    id="search-id-keyboard",
-                                    n_keydowns=0,
-                                ),
-                                dmc.Button(
-                                    "Search",
-                                    id="search-id-button",
-                                    n_clicks=0,
-                                ),
-                            ],
-                        ),
-                    ]),
-                ],
-            ),
-            dmc.Box(
-                id="message-banner",
-                children=[banner],
-                style={"marginBottom": "20px"},
-            ),
+            # Page head, key facts, lightcurve + sky view.
             dmc.Stack(
-                [
-                    dmc.Text(
-                        id="search-status",
-                        style={
-                            "padding": "10px",
-                            "fontStyle": "italic",
-                            "fontSize": "14px",
-                        },
-                        children=status,
-                    ),
-                    dmc.Stack(
-                        id="results-container",
-                        children=[results_top],
-                    ),
-                    # Citations sits half-half with the object tagging panel. The
-                    # tagging container lives here in the base layout (not inside
-                    # the search results) so its callbacks always have a target,
-                    # even on the empty page.
-                    dmc.Grid(
-                        [
-                            dmc.GridCol(citations_card, span=6),
-                            dmc.GridCol(
-                                html.Div(id="object-tagging-container"), span=6
-                            ),
-                        ],
-                        gutter="md",
-                    ),
-                    # Full metadata JSON dump pinned to the very bottom.
-                    full_metadata,
-                ],
+                id="results-container",
+                children=[results_top],
+                gap="md",
             ),
+            # Per-source metadata pairs with the tagging panel and citations.
+            # The tagging container lives here in the base layout (not inside
+            # the search results) so its callbacks always have a target, even
+            # on the empty page.
+            dmc.Grid(
+                [
+                    dmc.GridCol(metadata_card, span={"base": 12, "lg": 7}),
+                    dmc.GridCol(
+                        dmc.Stack(
+                            [
+                                html.Div(id="object-tagging-container"),
+                                citations_card,
+                            ],
+                            gap="md",
+                        ),
+                        span={"base": 12, "lg": 5},
+                    ),
+                ],
+                gutter="md",
+            ),
+            # Full metadata JSON dump pinned to the very bottom.
+            full_metadata,
         ],
+        gap="md",
     )
 
 
@@ -202,55 +174,44 @@ def search_navigation(n_clicks, n_keydowns, object_id):
     return f"/lightcurve/{object_id}"
 
 
+# The Aladin bootstrap lives in assets/lightcurve_aladin.js under an explicit
+# clientside namespace, matching assets/cone_aladin.js. Inline callback strings
+# are unreliable under Dash 4.
 clientside_callback(
-    """
-    function(storeData) {
-    if (!storeData || storeData.ra_deg === null || storeData.dec_deg === null) {
-        return "No TNS coordinates available for Aladin";
-    }
-
-    const ra = storeData.ra_deg;
-    const dec = storeData.dec_deg;
-
-    // log the coordinates for debugging
-    console.log("Initializing Aladin with coordinates:", ra, dec);
-
-    // The ID Plotly generates for pattern-matching is complex,
-    // so we target the container expressive_card or a stable parent.
-    const graphContainer = document.body;
-
-    const observer = new MutationObserver((mutations, obs) => {
-        // Look for the Plotly internal class that signifies rendering is done
-        const graphExists = document.querySelector('.js-plotly-plot');
-
-        if (graphExists) {
-            obs.disconnect(); // Stop watching
-
-            window.A.init.then(() => {
-                const container = document.getElementById('aladin-lite-div');
-                if (container) {
-                    container.innerHTML = '';
-                    window.A.aladin('#aladin-lite-div', {
-                        survey: 'P/PanSTARRS/DR1/color-z-zg-g',
-                        target: ra + ' ' + dec,
-                        fov: 0.025,
-                    });
-                }
-            });
-        }
-    });
-
-    observer.observe(graphContainer, {
-        childList: true,
-        subtree: true
-    });
-
-    return "Observer active";
-}
-    """,
+    ClientsideFunction(namespace="lightcurve_aladin", function_name="initialize"),
     Output("aladin-status-dummy", "children"),
     Input("lightcurve-aladin-store", "data"),
 )
+
+
+@callback(
+    [
+        Output("lc-plot-wrap", "style"),
+        Output("lc-table-wrap", "style"),
+        Output("lc-table-wrap", "children"),
+    ],
+    [
+        Input("lc-view-toggle", "value"),
+        Input("active-settings-store", "data"),
+    ],
+    State("lightcurve-store", "data"),
+    prevent_initial_call=True,
+)
+def toggle_lightcurve_view(view, settings, store):
+    """Swap the lightcurve card between the plot and the photometry table.
+
+    Also re-renders the table on a theme change so the band swatches follow the
+    colour scheme.
+    """
+    hidden = {"display": "none"}
+    shown = {"display": "block"}
+
+    if view != "Table":
+        return shown, hidden, no_update
+
+    scheme = scheme_from_template((settings or {}).get("theme"))
+    table = build_photometry_table((store or {}).get("data"), scheme)
+    return hidden, shown, table
 
 
 # Map source-keyed metadata source names to citation .bib file stems.
@@ -594,13 +555,20 @@ def perform_search(object_id, token, logger):
     """The core logic shared by both Button and URL triggers.
 
     Returns a tuple of
-    ``(results_top, citations_card, full_metadata, status, banner, lc_store,
-    aladin_store)``. The three render slots correspond to the pieces produced by
-    ``format_object_metadata``; ``layout`` drops them into the page so the
-    object-tagging container can stay in the always-present base layout.
+    ``(results_top, metadata_card, citations_card, full_metadata, status,
+    banner, lc_store, aladin_store)``. The four render slots correspond to the
+    pieces produced by ``format_object_metadata``; ``layout`` drops them into
+    the page so the object-tagging container can stay in the always-present
+    base layout.
     """
-    # Render slots used by every non-success early return (no object to show).
-    empty_render = (html.Div(), html.Div(), html.Div())
+    # Render slots used by every non-success early return: keep the search card
+    # on screen (pre-filled) so the user can correct the ID and retry.
+    empty_render = (
+        build_empty_search_state(prefill=object_id),
+        html.Div(),
+        html.Div(),
+        html.Div(),
+    )
 
     status_msg = f"Searching for object: {object_id}"
     logger.info({"search_type": "id", "object_id": object_id})
@@ -655,8 +623,8 @@ def perform_search(object_id, token, logger):
     )
 
     # Display metadata
-    results_top, citations_card, full_metadata = format_object_metadata(
-        object_id, meta, citation_str, logger
+    results_top, metadata_card, citations_card, full_metadata = format_object_metadata(
+        object_id, meta, citation_str, lc_data=lc_data, logger=logger
     )
     success_banner = create_message_banner(
         f"Successfully loaded object: {object_id}", "success"
@@ -675,6 +643,7 @@ def perform_search(object_id, token, logger):
 
     return (
         results_top,
+        metadata_card,
         citations_card,
         full_metadata,
         status_msg,

--- a/tarxiv/dashboard/pages/user.py
+++ b/tarxiv/dashboard/pages/user.py
@@ -17,7 +17,12 @@ from ...auth import (
     validate_token,
 )
 from ..components.auth import avatar_fallback, avatar_image
-from ..components.cards import create_message_banner, expressive_card, title_card
+from ..components.cards import (
+    create_message_banner,
+    expressive_card,
+    tag_badge,
+    title_card,
+)
 from ..styles import ORCID_BUTTON_STYLE, TAG_SWATCHES
 
 
@@ -951,13 +956,7 @@ def tag_section(title, tags):
                             [
                                 dmc.Group(
                                     [
-                                        dmc.Badge(
-                                            tag.get("name", "Unnamed"),
-                                            color=(tag.get("color") or "gray").lstrip(
-                                                "#"
-                                            ),
-                                            variant="light",
-                                        ),
+                                        tag_badge(tag),
                                         (
                                             dmc.Text(
                                                 tag.get("description"),

--- a/tarxiv/dashboard/pages/user.py
+++ b/tarxiv/dashboard/pages/user.py
@@ -18,7 +18,7 @@ from ...auth import (
 )
 from ..components.auth import avatar_fallback, avatar_image
 from ..components.cards import create_message_banner, expressive_card, title_card
-from ..styles import ORCID_BUTTON_STYLE
+from ..styles import ORCID_BUTTON_STYLE, TAG_SWATCHES
 
 
 dash.register_page(
@@ -541,18 +541,9 @@ def render_tag_create_form(team_memberships):
             dmc.ColorInput(
                 id="new-tag-color",
                 label="Color",
-                value="#7c3aed",
+                value=TAG_SWATCHES[0],
                 format="hex",
-                swatches=[
-                    "#7c3aed",
-                    "#2563eb",
-                    "#059669",
-                    "#d97706",
-                    "#dc2626",
-                    "#db2777",
-                    "#0891b2",
-                    "#4b5563",
-                ],
+                swatches=TAG_SWATCHES,
             ),
             dmc.Select(
                 id="new-tag-owner",

--- a/tarxiv/dashboard/styles.py
+++ b/tarxiv/dashboard/styles.py
@@ -1,83 +1,194 @@
-"""Styling constants for the dashboard."""
+"""Design tokens for the dashboard.
 
-# Common styles
-CARD_STYLE = {
-    "border": "1px solid #ddd",
-    "borderRadius": "8px",
-    "padding": "20px",
-    "marginBottom": "20px",
-    "boxShadow": "0 2px 4px rgba(0,0,0,0.1)",
-}
+Single source of truth for colour. ``theme_manager`` turns these into the
+Mantine theme, the generated ``assets/theme.css`` custom properties and the
+Plotly templates -- nothing else should hardcode a hex.
+"""
 
+PRIMARY = "#b31b1b"  # arXiv Mahogany Red
+
+# A real 10-step brand ramp. Mantine needs ten shades to make its ``light`` /
+# ``filled`` / ``outline`` variants and hover states differ; the previous
+# ``[PRIMARY] * 10`` made every variant identical. Index 6 is the brand hex.
+ARXIV_RED_RAMP = [
+    "#fdeaea",
+    "#f7cfcf",
+    "#eda6a6",
+    "#e37d7d",
+    "#d95454",
+    "#cb2a2a",
+    PRIMARY,
+    "#971616",
+    "#7a1212",
+    "#5c0d0d",
+]
+
+# Per-scheme surface/ink/accent tokens. Keys are shared between the two
+# schemes so ``generate_css`` can emit both by looping.
 COLORS = {
-    "primary": "#b31b1b",  # Mahogany Red
-    "bg_light": "#fefefe",  # White
-    "bg_dark": "#121617",  # Onyx
-    "surface_light": "#ebebf1",  # Ghost White
-    "surface_dark": "#212729",  # Jet Black
-    # "card_light": "#FDF6F6",  # Snow Pink
-    # "card_light": "#FEFAFA",  # Off White
-    "card_light": "#FDF4F4",  # Soft Pink
-    "card_dark": "#212729",  # Jet Black
-    "vlight_gray": "#F5F5F8",  # Very Light Gray
+    "primary": PRIMARY,
+    "light": {
+        "bg": "#f7f7f8",
+        "card": "#ffffff",
+        "card_2": "#f2f2f4",
+        "border": "rgba(18, 22, 23, 0.10)",
+        "border_strong": "rgba(18, 22, 23, 0.18)",
+        "ink": "#15191b",
+        "ink_2": "#5a6166",
+        "ink_3": "#8b9196",
+        "primary_hover": "#971616",
+        "primary_ink": PRIMARY,
+        "primary_soft": "rgba(179, 27, 27, 0.07)",
+        "primary_soft_2": "rgba(179, 27, 27, 0.14)",
+        "grid": "#ececef",
+        "axis": "#c9ccd0",
+        "shadow": "0 1px 2px rgba(18,22,23,0.05), 0 4px 16px rgba(18,22,23,0.05)",
+        "shadow_lg": "0 4px 12px rgba(18,22,23,0.08), 0 12px 40px rgba(18,22,23,0.10)",
+    },
+    "dark": {
+        "bg": "#121617",
+        "card": "#1c2224",
+        "card_2": "#242c2f",
+        "border": "rgba(255, 255, 255, 0.09)",
+        "border_strong": "rgba(255, 255, 255, 0.16)",
+        "ink": "#f2f4f5",
+        "ink_2": "#a9b2b7",
+        "ink_3": "#737d82",
+        "primary_hover": "#cb2a2a",
+        # Brand red is too dark to read as text on the dark surface; this is
+        # the lighter step used wherever red carries text/icon meaning.
+        "primary_ink": "#e06058",
+        "primary_soft": "rgba(224, 96, 88, 0.10)",
+        "primary_soft_2": "rgba(224, 96, 88, 0.18)",
+        "grid": "#262e31",
+        "axis": "#3d4649",
+        "shadow": "0 1px 2px rgba(0,0,0,0.25), 0 4px 16px rgba(0,0,0,0.25)",
+        "shadow_lg": "0 4px 12px rgba(0,0,0,0.35), 0 12px 40px rgba(0,0,0,0.40)",
+    },
 }
 
-# Filter colors for lightcurve plots
-FILTER_COLORS = {
-    # ZTF filters
-    "g": "green",
-    "R": "red",  # ZTF uses capital R
-    "i": "maroon",
-    # ATLAS filters
-    "c": "cyan",
-    "o": "orange",
-    "w": "teal",
-    # ASAS-SN filters
-    "V": "blue",
-    "g_ASAS-SN": "green",
-    # Other common filters
-    "u": "violet",
-    "r": "red",
-    "z": "purple",
-    "Unknown": "gray",
-    "search_position": "#e74c3c",  # Nice bright red
-    "object": "#4C84C6",  # Nice bright blue
+# The footer keeps its dark plate in both schemes so the partner logos hold
+# contrast; exposed as a token rather than being hardcoded in ``footer_card``.
+FOOTER_BG = "#1c2224"
+
+
+# --------------------------------------------------------------------------
+# Lightcurve series styling
+#
+# Both colour AND marker symbol encode the photometric BAND; the survey is
+# carried by the legend group and the series label. Pairing the two channels
+# is deliberate: the g/r pair sits in the 6-8 CVD separation band, which is
+# only legal alongside a secondary encoding, so shape has to move with hue
+# rather than being spent on the survey. Two surveys observing the same
+# bandpass therefore look alike, which is the scientifically honest reading --
+# they are the same measurement -- and the legend and table tell them apart.
+#
+# Colours were validated with the dataviz palette validator (all-pairs, i.e.
+# the scatter pairlist) against both card surfaces, #ffffff and #1c2224. The
+# four bands that actually co-occur in TarXiv data -- g/r from ZTF plus c/o
+# from ATLAS -- pass every gate in both schemes. Beyond four series no
+# ordering of eight hues can clear the all-pairs CVD floors, so the rarer
+# bands below sit past that documented cap: every one is in the lightness band
+# with chroma above the floor, and identity for them leans on the symbol, the
+# legend label and the photometry table view (which is also the relief channel
+# for amber `o` and magenta `z`, both sub-3:1 on the light surface).
+# --------------------------------------------------------------------------
+
+BAND_COLORS = {
+    # band: (light, dark)
+    "u": ("#4a3aa7", "#9085e9"),  # violet
+    "c": ("#2a78d6", "#3987e5"),  # blue      -- validated core
+    "g": ("#199e70", "#199e70"),  # green     -- validated core
+    "V": ("#00663c", "#22a022"),  # deep green
+    "r": ("#e34948", "#e34948"),  # red       -- validated core
+    "o": ("#eda100", "#c98500"),  # amber     -- validated core
+    "i": ("#952424", "#c04544"),  # deep red
+    "z": ("#e87ba4", "#d55181"),  # magenta
+    "w": ("#eb6834", "#d95926"),  # orange
+    # Anything unrecognised folds into a neutral rather than inventing a hue.
+    "Unknown": ("#8b9196", "#737d82"),
 }
 
-# Auth/navigation styling
-NAVBAR_STYLE = {
-    "display": "flex",
-    "alignItems": "center",
-    "justifyContent": "space-between",
-    "padding": "16px 24px",
-    "backgroundColor": "#ffffff",
-    "borderBottom": "1px solid #e5e7eb",
-    "boxShadow": "0 1px 4px rgba(0,0,0,0.06)",
-    "position": "sticky",
-    "top": 0,
-    "zIndex": 100,
+# Distinct shapes per band, so the green/red pair (and every other pair) stays
+# separable without colour.
+BAND_SYMBOLS = {
+    "u": "hexagon",
+    "c": "diamond",
+    "g": "circle",
+    "V": "star",
+    "r": "square",
+    "o": "triangle-up",
+    "i": "pentagon",
+    "z": "triangle-down",
+    "w": "cross",
+    "Unknown": "x",
 }
 
-NAV_TITLE_STYLE = {
-    "display": "flex",
-    "flexDirection": "column",
-    "gap": "4px",
+# ZTF reports its red band as a capital "R"; ASAS-SN's green arrives as
+# "g_ASAS-SN" from older ingests.
+_BAND_ALIASES = {
+    "R": "r",
+    "g_asas-sn": "g",
+    "g_asas_sn": "g",
+    "y": "z",  # LSST y sits redward of z; share the magenta family
 }
 
-NAV_RIGHT_STYLE = {
-    "display": "flex",
-    "alignItems": "center",
-    "gap": "12px",
-}
 
-USER_CHIP_STYLE = {
-    "display": "flex",
-    "alignItems": "center",
-    "gap": "10px",
-    "padding": "6px 10px",
-    "border": "1px solid #e5e7eb",
-    "borderRadius": "20px",
-    "backgroundColor": "#f8fafc",
+def _canonical_band(filter_name: str | None) -> str:
+    """Normalise a raw filter name onto a known band key."""
+    band = (filter_name or "Unknown").strip()
+    if band not in BAND_COLORS:
+        band = _BAND_ALIASES.get(band, _BAND_ALIASES.get(band.lower(), band))
+    return band if band in BAND_COLORS else "Unknown"
+
+
+def resolve_filter_style(survey: str | None, filter_name: str | None) -> dict:
+    """Resolve a ``(survey, filter)`` pair to marker styling.
+
+    Returns a dict with ``light``, ``dark`` and ``symbol`` keys. ``survey`` is
+    accepted so callers can pass the full series identity (and so a future
+    survey-specific override has somewhere to live), but styling is currently
+    driven by the band alone -- see the note above ``BAND_COLORS``. Unknown
+    bands fold to a neutral colour and the ``x`` symbol rather than generating
+    new hues.
+    """
+    band = _canonical_band(filter_name)
+    light, dark = BAND_COLORS[band]
+    return {"light": light, "dark": dark, "symbol": BAND_SYMBOLS[band]}
+
+
+def band_color(filter_name: str | None, scheme: str = "light") -> str:
+    """Colour for a band (used by the photometry table swatches)."""
+    light, dark = BAND_COLORS[_canonical_band(filter_name)]
+    return dark if scheme == "dark" else light
+
+
+# Categorical swatches offered when a user picks a tag colour.
+TAG_SWATCHES = [
+    PRIMARY,
+    "#2a78d6",
+    "#199e70",
+    "#eda100",
+    "#eb6834",
+    "#4a3aa7",
+    "#e87ba4",
+    "#5a6166",
+]
+
+
+# --------------------------------------------------------------------------
+# Legacy inline styles. These predate the Mantine migration; only the ones
+# below are still referenced (cone result cards, the avatar in components/
+# auth.py and the ORCID button in pages/user.py).
+# --------------------------------------------------------------------------
+
+CARD_STYLE = {
+    "border": "1px solid var(--tarxiv-border)",
+    "borderRadius": "10px",
+    "padding": "16px",
+    "marginBottom": "12px",
+    "backgroundColor": "var(--tarxiv-card)",
+    "boxShadow": "var(--tarxiv-shadow)",
 }
 
 AVATAR_STYLE = {
@@ -85,15 +196,15 @@ AVATAR_STYLE = {
     "height": "32px",
     "borderRadius": "50%",
     "objectFit": "cover",
-    "border": "1px solid #e5e7eb",
+    "border": "1px solid var(--tarxiv-border-strong)",
 }
 
 AVATAR_FALLBACK_STYLE = {
     "width": "32px",
     "height": "32px",
     "borderRadius": "50%",
-    "backgroundColor": "#3498db",
-    "color": "white",
+    "backgroundColor": "var(--tarxiv-primary-soft-2)",
+    "color": "var(--tarxiv-primary-ink)",
     "display": "flex",
     "alignItems": "center",
     "justifyContent": "center",
@@ -102,66 +213,16 @@ AVATAR_FALLBACK_STYLE = {
 }
 
 BUTTON_STYLE = {
-    "backgroundColor": "#3498db",
-    "color": "white",
     "border": "none",
-    "borderRadius": "4px",
-    "padding": "10px 20px",
+    "borderRadius": "8px",
+    "padding": "8px 16px",
     "fontSize": "14px",
     "cursor": "pointer",
     "fontWeight": "500",
 }
 
-LOGIN_BUTTON_STYLE = {**BUTTON_STYLE, "padding": "8px 16px"}
-SIGNUP_BUTTON_STYLE = {
-    **BUTTON_STYLE,
-    "padding": "8px 16px",
-    "backgroundColor": "#1abc9c",
-}
 ORCID_BUTTON_STYLE = {
     **BUTTON_STYLE,
-    "padding": "8px 16px",
-    "backgroundColor": "#a6ce39",
+    "backgroundColor": "#a6ce39",  # ORCID brand green
     "color": "#102b08",
 }
-PROFILE_BUTTON_STYLE = {
-    **BUTTON_STYLE,
-    "padding": "6px 12px",
-    "backgroundColor": "#95a5a6",
-}
-
-AUTH_MODAL_STYLE = {
-    "position": "fixed",
-    "top": 0,
-    "left": 0,
-    "width": "100%",
-    "height": "100%",
-    "backgroundColor": "rgba(0,0,0,0.35)",
-    "display": "none",
-    "alignItems": "center",
-    "justifyContent": "center",
-    "zIndex": 200,
-}
-
-AUTH_MODAL_CONTENT_STYLE = {
-    "backgroundColor": "white",
-    "padding": "24px",
-    "borderRadius": "12px",
-    "width": "360px",
-    "boxShadow": "0 8px 20px rgba(0,0,0,0.1)",
-}
-
-PROFILE_DRAWER_STYLE = {
-    "position": "fixed",
-    "top": 0,
-    "right": "-400px",
-    "width": "360px",
-    "height": "100%",
-    "backgroundColor": "#ffffff",
-    "boxShadow": " -2px 0 12px rgba(0,0,0,0.15)",
-    "padding": "24px",
-    "transition": "right 0.3s ease",
-    "zIndex": 150,
-}
-
-PROFILE_DRAWER_OPEN_STYLE = {**PROFILE_DRAWER_STYLE, "right": "0"}

--- a/tarxiv/data_sources.py
+++ b/tarxiv/data_sources.py
@@ -1012,25 +1012,6 @@ class AlerceMod(TarxivModule):
                 meta = None
                 raise SurveyMetaMissingError
 
-            # Get object
-            lsst_obj = lsst_df.iloc[0]
-            # Get probabilities
-            result = self.client.query_probabilities(oid=lsst_obj.oid, survey="lsst")
-            prob_df = pd.DataFrame(result)
-            prob_info = prob_df[
-                (prob_df["classifier_name"] == self.config["alerce_lsst"]["classifier"])
-                & (prob_df["ranking"] == 1)
-            ]
-
-            meta = {
-                "object_id": lsst_obj.oid,
-                "classifier": {
-                    "name": prob_info.classifier_name,
-                    "version": prob_info.classifier_version,
-                    "probability": prob_info.probability,
-                    "result": prob_info.class_name,
-                },
-            }
 
         except SurveyMetaMissingError:
             status["status"] = "no match"

--- a/tarxiv/data_sources.py
+++ b/tarxiv/data_sources.py
@@ -897,9 +897,11 @@ class AlerceMod(TarxivModule):
 
         try:
             # Now get lsst
-            lsst_df = self.client.query_objects(ra=ra_deg, dec=dec_deg, radius=radius, survey="lsst")
+            lsst_df = self.client.query_objects(
+                ra=ra_deg, dec=dec_deg, radius=radius, survey="lsst"
+            )
             if "oid" in lsst_df.columns and not lsst_df["oid"].empty:
-                lsst_id = lsst_df["oid"].iat[0]
+                lsst_id = lsst_df["oid"].iloc[0]
                 meta["lsst_object_id"] = str(lsst_id)
 
                 # Get probabilities

--- a/tarxiv/data_sources.py
+++ b/tarxiv/data_sources.py
@@ -1012,7 +1012,6 @@ class AlerceMod(TarxivModule):
                 meta = None
                 raise SurveyMetaMissingError
 
-
         except SurveyMetaMissingError:
             status["status"] = "no match"
 

--- a/tarxiv/openapi.py
+++ b/tarxiv/openapi.py
@@ -683,7 +683,6 @@ def build_openapi_spec() -> dict:
             "/get_object_meta/{obj_name}": {
                 "post": {
                     "summary": "Get object metadata",
-                    "security": bearer_auth,
                     "parameters": [
                         {
                             "name": "obj_name",
@@ -703,7 +702,6 @@ def build_openapi_spec() -> dict:
                                 }
                             },
                         },
-                        "401": {"description": "Unauthorized"},
                         "404": {"description": "Object not found"},
                     },
                 }
@@ -711,7 +709,6 @@ def build_openapi_spec() -> dict:
             "/get_object_lc/{obj_name}": {
                 "post": {
                     "summary": "Get object lightcurve",
-                    "security": bearer_auth,
                     "parameters": [
                         {
                             "name": "obj_name",
@@ -734,7 +731,6 @@ def build_openapi_spec() -> dict:
                                 }
                             },
                         },
-                        "401": {"description": "Unauthorized"},
                         "404": {"description": "Object not found"},
                     },
                 }
@@ -742,7 +738,6 @@ def build_openapi_spec() -> dict:
             "/tns_alerts": {
                 "post": {
                     "summary": "List recent TNS alerts",
-                    "security": bearer_auth,
                     "requestBody": {
                         "required": True,
                         "content": {
@@ -752,13 +747,6 @@ def build_openapi_spec() -> dict:
                                     "properties": {
                                         "n_rows": {"type": "integer"},
                                         "offset": {"type": "integer"},
-                                        "tag_ids": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string",
-                                                "format": "uuid",
-                                            },
-                                        },
                                     },
                                     "required": ["n_rows", "offset"],
                                 }
@@ -777,14 +765,13 @@ def build_openapi_spec() -> dict:
                                 }
                             },
                         },
-                        "401": {"description": "Unauthorized"},
+                        "400": {"description": "Invalid paging parameters"},
                     },
                 }
             },
             "/search_objects": {
                 "post": {
                     "summary": "Search objects by metadata conditions",
-                    "security": bearer_auth,
                     "requestBody": {
                         "required": True,
                         "content": {
@@ -808,14 +795,12 @@ def build_openapi_spec() -> dict:
                                 }
                             },
                         },
-                        "401": {"description": "Unauthorized"},
                     },
                 }
             },
             "/cone_search": {
                 "post": {
                     "summary": "Cone search around sky coordinates",
-                    "security": bearer_auth,
                     "requestBody": {
                         "required": True,
                         "content": {
@@ -846,7 +831,6 @@ def build_openapi_spec() -> dict:
                                 }
                             },
                         },
-                        "401": {"description": "Unauthorized"},
                     },
                 }
             },

--- a/tarxiv/pipeline.py
+++ b/tarxiv/pipeline.py
@@ -59,12 +59,14 @@ class TNSPipeline(TarxivModule):
         )
 
         # Get kafka configuration
-        conf = {'bootstrap.servers': os.environ['TARXIV_KAFKA_INTERNAL_HOST'] + ":9092",
-                'delivery.timeout.ms': 10000,
-                'queue.buffering.max.messages': 1000000,
-                'queue.buffering.max.ms': 5000,
-                'batch.num.messages': 100,
-                'client.id': socket.gethostname()}
+        conf = {
+            "bootstrap.servers": os.environ["TARXIV_KAFKA_INTERNAL_HOST"] + ":9092",
+            "delivery.timeout.ms": 10000,
+            "queue.buffering.max.messages": 1000000,
+            "queue.buffering.max.ms": 5000,
+            "batch.num.messages": 100,
+            "client.id": socket.gethostname(),
+        }
         self.producer = Producer(conf)
         self.consumer = None
 
@@ -75,7 +77,6 @@ class TNSPipeline(TarxivModule):
             signal.signal(signal.SIGTERM, self.signal_handler)
         else:
             self.stop_event = None
-
 
     def signal_handler(self, sig, frame):
         status = {
@@ -305,7 +306,9 @@ class TNSPipeline(TarxivModule):
                 object_id = obj["name"]
 
             # Push to bulk update
-            self.producer.produce(topic="tns_bulk", value=object_id, callback=self.acked)
+            self.producer.produce(
+                topic="tns_bulk", value=object_id, callback=self.acked
+            )
 
     def daily_update(self):
         # Get all targets still in "active" window for update
@@ -321,24 +324,30 @@ class TNSPipeline(TarxivModule):
         # Submit missing IDs for bulk pulls
         missing_ids = list(set(all_tns_ids) - set(cur_tns_ids))
         for object_id in missing_ids:
-            self.producer.produce(topic="tns_bulk", value=object_id, callback=self.acked)
+            self.producer.produce(
+                topic="tns_bulk", value=object_id, callback=self.acked
+            )
 
         # Submit updates to update pipeline
         for object_id in missing_ids:
-            self.producer.produce(topic="tns_updates", value=object_id, callback=self.acked)
+            self.producer.produce(
+                topic="tns_updates", value=object_id, callback=self.acked
+            )
 
         # Finish by flushing
         self.producer.flush(timeout=10.0)
 
     def run_pipeline(self, topic):
         # Connect to kafka consumer
-        conf = {'bootstrap.servers': os.environ['TARXIV_KAFKA_INTERNAL_HOST'] + ":9092",
-                'group.id': "tns_pipeline",
-                'auto.offset.reset': 'earliest',
-                'enable.auto.commit': False,
-                'max.poll.interval.ms': 3600000,
-                'session.timeout.ms': 1200000,
-                'heartbeat.interval.ms': 3000}
+        conf = {
+            "bootstrap.servers": os.environ["TARXIV_KAFKA_INTERNAL_HOST"] + ":9092",
+            "group.id": "tns_pipeline",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+            "max.poll.interval.ms": 3600000,
+            "session.timeout.ms": 1200000,
+            "heartbeat.interval.ms": 3000,
+        }
         self.consumer = Consumer(conf)
         self.consumer.subscribe([topic], on_assign=self.print_assignment)
         # Start up
@@ -374,10 +383,11 @@ class TNSPipeline(TarxivModule):
 
                         # New alerts send hopskotch and kafka, also queue up forced phot
                         if topic == "tns_alerts":
-
                             # Submit to hopskotch
                             stream = Stream(self.hop_auth)
-                            with stream.open("kafka://kafka.scimma.org/tarxiv.tns", "w") as s:
+                            with stream.open(
+                                "kafka://kafka.scimma.org/tarxiv.tns", "w"
+                            ) as s:
                                 # Additional information for hopskotch
                                 s.write(obj_meta)
                                 status = {
@@ -386,13 +396,16 @@ class TNSPipeline(TarxivModule):
                                 }
                                 self.logger.info(status, extra=status)
                             # Submit kafka alert
-                            msg = json.dumps(obj_meta).encode('utf-8')
-                            self.producer.produce(topic='tns', value=msg, callback=self.acked)
+                            msg = json.dumps(obj_meta).encode("utf-8")
+                            self.producer.produce(
+                                topic="tns", value=msg, callback=self.acked
+                            )
                             self.consumer.commit(asynchronous=False)
 
-
                     elif topic in ["tns_updates"]:
-                        txv_id, obj_meta, obj_lc = self.update_active_object(tns_object_id)
+                        txv_id, obj_meta, obj_lc = self.update_active_object(
+                            tns_object_id
+                        )
                         # Get timestamp
                         timestamp = (
                             datetime.datetime.now().replace(microsecond=0).isoformat()
@@ -445,13 +458,15 @@ class ForcedPhotWorker(TarxivModule):
 
     def run_pipeline(self, survey_name, queue_type, worker_id, stop_event):
         # Connect to kafka consumer
-        conf = {'bootstrap.servers': os.environ['TARXIV_KAFKA_INTERNAL_HOST'] + ":9092",
-                'group.id': "forced_phot_worker_pool",
-                'auto.offset.reset': 'earliest',
-                'enable.auto.commit': False,
-                'max.poll.interval.ms': 3600000,
-                'session.timeout.ms': 1200000,
-                'heartbeat.interval.ms': 3000}
+        conf = {
+            "bootstrap.servers": os.environ["TARXIV_KAFKA_INTERNAL_HOST"] + ":9092",
+            "group.id": "forced_phot_worker_pool",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+            "max.poll.interval.ms": 3600000,
+            "session.timeout.ms": 1200000,
+            "heartbeat.interval.ms": 3000,
+        }
         self.consumer = Consumer(conf)
         # Topic name will be given by our survey name
         topic = f"{survey_name}_{queue_type}_forced_phot"
@@ -587,14 +602,15 @@ class ForcedPhotPipelineUtil(TarxivModule):
         # Get database
         self.db = TarxivDB("pipeline", script_name, reporting_mode, debug)
         # Get kafka configuration
-        conf = {'bootstrap.servers': os.environ['TARXIV_KAFKA_INTERNAL_HOST'] + ":9092",
-                'delivery.timeout.ms': 10000,
-                'queue.buffering.max.messages': 1000000,
-                'queue.buffering.max.ms': 5000,
-                'batch.num.messages': 100,
-                'client.id': socket.gethostname()}
+        conf = {
+            "bootstrap.servers": os.environ["TARXIV_KAFKA_INTERNAL_HOST"] + ":9092",
+            "delivery.timeout.ms": 10000,
+            "queue.buffering.max.messages": 1000000,
+            "queue.buffering.max.ms": 5000,
+            "batch.num.messages": 100,
+            "client.id": socket.gethostname(),
+        }
         self.producer = Producer(conf)
-
 
     def queue_phot_job(self, txv_id, survey_name, queue_type):
         topic = f"{survey_name}_{queue_type}_forced_phot"

--- a/tarxiv/pipeline.py
+++ b/tarxiv/pipeline.py
@@ -69,6 +69,11 @@ class TNSPipeline(TarxivModule):
         }
         self.producer = Producer(conf)
         self.consumer = None
+        # Forced phot utils
+        self.phot_util = ForcedPhotPipelineUtil(script_name="forced_phot_submit",
+                                                reporting_mode=reporting_mode,
+                                                debug=debug)
+        self.forced_phot_services = ["atlas"]
 
         # Signal handling
         if not debug:
@@ -383,6 +388,10 @@ class TNSPipeline(TarxivModule):
 
                         # New alerts send hopskotch and kafka, also queue up forced phot
                         if topic == "tns_alerts":
+                            # Queue up phot job
+                            for survey in self.forced_phot_services:
+                                self.phot_util.queue_phot_job(txv_id, survey, "alerts")
+
                             # Submit to hopskotch
                             stream = Stream(self.hop_auth)
                             with stream.open(

--- a/tarxiv/pipeline.py
+++ b/tarxiv/pipeline.py
@@ -70,9 +70,9 @@ class TNSPipeline(TarxivModule):
         self.producer = Producer(conf)
         self.consumer = None
         # Forced phot utils
-        self.phot_util = ForcedPhotPipelineUtil(script_name="forced_phot_submit",
-                                                reporting_mode=reporting_mode,
-                                                debug=debug)
+        self.phot_util = ForcedPhotPipelineUtil(
+            script_name="forced_phot_submit", reporting_mode=reporting_mode, debug=debug
+        )
         self.forced_phot_services = ["atlas"]
 
         # Signal handling

--- a/tarxiv/pipeline.py
+++ b/tarxiv/pipeline.py
@@ -414,11 +414,12 @@ class TNSPipeline(TarxivModule):
                         obj_meta["update_date"] = timestamp
                         # Upsert to database
                         self.upsert_object(txv_id, obj_meta, obj_lc)
-                        self.consumer.commit(asynchronous=False)
 
                     else:
                         status = {"status": "bad topic somehow", "topic": topic}
                         self.logger.error(status, extra=status)
+                    # Commit
+                    self.consumer.commit(asynchronous=False)
 
                 except Exception:
                     stack_trace = traceback.format_exc()
@@ -469,7 +470,7 @@ class ForcedPhotWorker(TarxivModule):
         }
         self.consumer = Consumer(conf)
         # Topic name will be given by our survey name
-        topic = f"{survey_name}_{queue_type}_forced_phot"
+        topic = f"forced_phot_{survey_name}_{queue_type}"
         self.consumer.subscribe([topic], on_assign=self.print_assignment)
         # Start up
         status = {"status": "running pipeline", "worker_id": worker_id}
@@ -613,7 +614,7 @@ class ForcedPhotPipelineUtil(TarxivModule):
         self.producer = Producer(conf)
 
     def queue_phot_job(self, txv_id, survey_name, queue_type):
-        topic = f"{survey_name}_{queue_type}_forced_phot"
+        topic = f"forced_phot_{survey_name}_{queue_type}"
         status = {"status": "submitting phot job", "topic": topic, "txv_id": txv_id}
         self.logger.info(status, extra=status)
         self.producer.produce(topic=topic, value=txv_id, callback=self.acked)

--- a/tarxiv/tests/test_api.py
+++ b/tarxiv/tests/test_api.py
@@ -69,14 +69,15 @@ def test_get_object_meta_success(mock_api):
     assert response.json == {"foo": "bar"}
 
 
-def test_get_object_meta_bad_token(mock_api):
-    # No valid token -> the auth check rejects the request before any DB call.
+def test_get_object_meta_allows_anonymous(mock_api):
+    # Metadata is public: no Authorization header at all must still return data.
     client = mock_api.app.test_client()
-    response = client.post(
-        "/get_object_meta/test_obj", json={}, headers={"Authorization": "WRONG"}
-    )
-    assert response.status_code == 401
-    assert response.json["error"] == "Invalid or missing token."
+    mock_api.txv_db.get.return_value = {"foo": "bar"}
+
+    response = client.post("/get_object_meta/test_obj", json={})
+
+    assert response.status_code == 200
+    assert response.json == {"foo": "bar"}
 
 
 def test_get_object_meta_missing_obj(mock_api):
@@ -552,7 +553,7 @@ def test_delete_object_tag_success(mock_api, auth_token):
     assert response.json["status"] == "deleted"
 
 
-def test_tns_alerts_success(mock_api, auth_token):
+def test_tns_alerts_success(mock_api):
     # The alerts page reads obj_name/discovery_date/object_type/ra_hms/dec_dms/...
     # so the endpoint must emit exactly those keys. We stub the data layer to
     # return one such row and assert it is serialized back.
@@ -570,18 +571,14 @@ def test_tns_alerts_success(mock_api, auth_token):
         }
     ]
 
-    response = client.post(
-        "/tns_alerts",
-        json={"n_rows": 25, "offset": 0},
-        headers={"Authorization": auth_token},
-    )
+    response = client.post("/tns_alerts", json={"n_rows": 25, "offset": 0})
 
     assert response.status_code == 200
     assert response.json[0]["obj_name"] == "2018mqw"
     assert response.json[0]["ra_hms"] == "12:38:29.211744"
 
 
-def test_tns_alerts_query_reads_source_keyed_schema(mock_api, auth_token):
+def test_tns_alerts_query_reads_source_keyed_schema(mock_api):
     """Alerts query must read TNS fields from the source-keyed schema.
 
     Regression: under the source-keyed schema the TNS fields live under
@@ -592,11 +589,7 @@ def test_tns_alerts_query_reads_source_keyed_schema(mock_api, auth_token):
     client = mock_api.app.test_client()
     mock_api.txv_db.query.return_value = []
 
-    response = client.post(
-        "/tns_alerts",
-        json={"n_rows": 25, "offset": 0},
-        headers={"Authorization": auth_token},
-    )
+    response = client.post("/tns_alerts", json={"n_rows": 25, "offset": 0})
 
     assert response.status_code == 200
     statement = mock_api.txv_db.query.call_args.args[0]
@@ -606,25 +599,37 @@ def test_tns_alerts_query_reads_source_keyed_schema(mock_api, auth_token):
     assert "meta.tns." not in statement
 
 
-def test_tns_alerts_requires_token(mock_api):
+def test_tns_alerts_allows_anonymous(mock_api):
+    # Alerts are public: no Authorization header at all must still list them.
     client = mock_api.app.test_client()
-    response = client.post(
-        "/tns_alerts",
-        json={"n_rows": 25, "offset": 0},
-        headers={"Authorization": "WRONG"},
-    )
-    assert response.status_code == 401
+    mock_api.txv_db.query.return_value = []
+
+    response = client.post("/tns_alerts", json={"n_rows": 25, "offset": 0})
+
+    assert response.status_code == 200
 
 
-def test_tns_alerts_rejects_non_integer_paging(mock_api, auth_token):
+def test_tns_alerts_rejects_non_integer_paging(mock_api):
+    # n_rows/offset are interpolated straight into the query string, so this
+    # check is the whole guard against injection now the route is public.
     client = mock_api.app.test_client()
-    response = client.post(
-        "/tns_alerts",
-        json={"n_rows": "lots", "offset": 0},
-        headers={"Authorization": auth_token},
-    )
-    assert response.status_code == 500
-    assert response.json["type"] == "server"
+
+    response = client.post("/tns_alerts", json={"n_rows": "lots", "offset": 0})
+
+    assert response.status_code == 400
+    assert response.json["type"] == "validation"
+    mock_api.txv_db.query.assert_not_called()
+
+
+def test_search_objects_allows_anonymous(mock_api):
+    # Object search is public: no Authorization header must still return matches.
+    client = mock_api.app.test_client()
+    mock_api.txv_db.query.return_value = [{"object_id": "2018mqw"}]
+
+    response = client.post("/search_objects", json={"search": {}})
+
+    assert response.status_code == 200
+    assert response.json == ["2018mqw"]
 
 
 def test_cone_search_route_returns_results(mock_api):

--- a/tarxiv/tests/test_dashboard_cone.py
+++ b/tarxiv/tests/test_dashboard_cone.py
@@ -77,3 +77,107 @@ def test_parse_combined_coordinates_blank(cone_module):
 def test_parse_combined_coordinates_invalid(cone_module, combined):
     with pytest.raises(ValueError):
         cone_module.parse_combined_coordinates(combined)
+
+
+def test_build_cone_query_string(cone_module):
+    query = cone_module.build_cone_query_string(315.40375, 68.1633333333, 30.0)
+
+    assert query == "?ra=315.403750&dec=68.163333&radius=30"
+
+
+def test_cone_query_string_round_trips(cone_module):
+    query = cone_module.build_cone_query_string(315.40375, -68.1633333333, 5.5)
+    ra, dec, radius = cone_module.parse_cone_search_string(query)
+
+    assert ra == pytest.approx(315.40375, abs=1e-6)
+    assert dec == pytest.approx(-68.1633333333, abs=1e-6)
+    assert radius == pytest.approx(5.5)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"ra": "", "dec": "", "radius": ""},
+        {"unrelated": "value"},
+    ],
+)
+def test_parse_cone_query_params_absent(cone_module, params):
+    assert cone_module.parse_cone_query_params(params) is None
+
+
+@pytest.mark.parametrize("search", ["", None])
+def test_parse_cone_search_string_empty(cone_module, search):
+    assert cone_module.parse_cone_search_string(search) is None
+
+
+def test_parse_cone_search_string_without_leading_question_mark(cone_module):
+    assert cone_module.parse_cone_search_string("ra=10&dec=20&radius=5") == (
+        10.0,
+        20.0,
+        5.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"ra": "10", "dec": "20"},  # missing radius
+        {"ra": "10", "radius": "5"},  # missing dec
+        {"dec": "20", "radius": "5"},  # missing ra
+    ],
+)
+def test_parse_cone_query_params_incomplete(cone_module, params):
+    with pytest.raises(ValueError, match="Incomplete"):
+        cone_module.parse_cone_query_params(params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"ra": "abc", "dec": "20", "radius": "5"},
+        {"ra": "10", "dec": "not_a_number", "radius": "5"},
+        {"ra": "10", "dec": "20", "radius": "wide"},
+    ],
+)
+def test_parse_cone_query_params_non_numeric(cone_module, params):
+    with pytest.raises(ValueError, match="must all be numbers"):
+        cone_module.parse_cone_query_params(params)
+
+
+@pytest.mark.parametrize(
+    ("params", "match"),
+    [
+        ({"ra": "361", "dec": "20", "radius": "5"}, "RA must be"),
+        ({"ra": "-1", "dec": "20", "radius": "5"}, "RA must be"),
+        ({"ra": "10", "dec": "91", "radius": "5"}, "Dec must be"),
+        ({"ra": "10", "dec": "-91", "radius": "5"}, "Dec must be"),
+        ({"ra": "10", "dec": "20", "radius": "0"}, "Radius must be"),
+        ({"ra": "10", "dec": "20", "radius": "-5"}, "Radius must be"),
+    ],
+)
+def test_parse_cone_query_params_out_of_range(cone_module, params, match):
+    with pytest.raises(ValueError, match=match):
+        cone_module.parse_cone_query_params(params)
+
+
+def test_parse_cone_query_params_accepts_boundaries(cone_module):
+    assert cone_module.parse_cone_query_params({
+        "ra": "0",
+        "dec": "-90",
+        "radius": "0.001",
+    }) == (0.0, -90.0, 0.001)
+    assert cone_module.parse_cone_query_params({
+        "ra": "360",
+        "dec": "90",
+        "radius": "1",
+    }) == (360.0, 90.0, 1.0)
+
+
+def test_parse_cone_query_params_accepts_numeric_values(cone_module):
+    """layout() passes floats straight through when Dash has already coerced."""
+    assert cone_module.parse_cone_query_params({
+        "ra": 10.0,
+        "dec": 20.0,
+        "radius": 5.0,
+    }) == (10.0, 20.0, 5.0)

--- a/tarxiv/tests/test_dashboard_layout.py
+++ b/tarxiv/tests/test_dashboard_layout.py
@@ -1,0 +1,118 @@
+"""Tests for the app shell and page-layout construction.
+
+Dash validates component props in ``Component.__init__``, so simply building a
+layout catches invalid props -- for example a Mantine style prop such as
+``visibleFrom`` passed to an ``html.*`` component, which raises at construction
+and takes the whole dashboard down on first page load.
+
+The shell also owns the ids that the callbacks in ``callbacks/style_callbacks.py``
+bind to. A renamed or dropped id there is a runtime error ("A nonexistent object
+was used in an Output"), not a cosmetic problem, so those ids are asserted
+explicitly.
+"""
+
+import importlib
+from unittest.mock import MagicMock
+
+import dash
+import flask
+import pytest
+
+from tarxiv.tests.test_dashboard_lightcurve import collect_component_ids
+
+# Ids the shell must provide because callbacks target them.
+# style_callbacks.py: theme toggle, plot repaint, nav refresh, global search, burger.
+# cookie_callbacks.py: consent/settings stores.
+SHELL_CALLBACK_IDS = {
+    "app-shell",
+    "topbar-nav",
+    "mobile-nav-content",
+    "color-scheme-toggle",
+    "theme-icon",
+    "burger",
+    "global-search-input",
+    "global-search-keyboard",
+    "url",
+    "active-settings-store",
+    "local-settings-store",
+    "cookie-consent-store",
+    "page-content",
+    "dummy-output",
+}
+
+# Pages built here. Every one reads the request (for the auth token) and/or
+# current_app, so they all need a request context. The lightcurve page has its
+# own dedicated tests in test_dashboard_lightcurve.py.
+PAGES = ["home", "alerts", "tagged", "cone"]
+
+
+@pytest.fixture
+def main_layout():
+    import tarxiv.dashboard.layouts.main_layout as module
+
+    return module
+
+
+def _build_shell(main_layout):
+    """Build the shell inside a request context, as a real page load would."""
+    app = flask.Flask(__name__)
+    app.config["TXV_LOGGER"] = MagicMock()
+    with app.test_request_context("/"):
+        return main_layout.create_layout()
+
+
+def test_create_layout_builds(main_layout):
+    """The app shell must construct without raising.
+
+    Regression: ``html.Div(id="topbar-nav", visibleFrom="sm")`` raised a
+    TypeError because ``visibleFrom`` is a Mantine style prop that Dash's
+    ``html.*`` components reject. Nothing exercised the shell, so it only
+    surfaced when the dashboard was actually served.
+    """
+    assert _build_shell(main_layout) is not None
+
+
+def test_create_layout_builds_without_request_context(main_layout):
+    """The shell must build with no request context.
+
+    ``app.layout`` is assigned the callable and re-evaluated per page load;
+    ``create_layout`` guards on ``has_request_context`` for the auth lookup.
+    """
+    assert main_layout.create_layout() is not None
+
+
+def test_shell_contains_callback_target_ids(main_layout):
+    """Every id the callbacks bind to must exist in the shell."""
+    ids = collect_component_ids(_build_shell(main_layout))
+
+    missing = SHELL_CALLBACK_IDS - ids
+    assert not missing, f"shell is missing callback target ids: {sorted(missing)}"
+
+
+@pytest.fixture
+def page_module(request, monkeypatch):
+    """Import a page module with page/callback registration neutralised."""
+    monkeypatch.setattr(dash, "register_page", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dash, "callback", lambda *args, **kwargs: lambda f: f)
+    monkeypatch.setattr(dash, "clientside_callback", lambda *args, **kwargs: None)
+
+    module = importlib.import_module(f"tarxiv.dashboard.pages.{request.param}")
+    return importlib.reload(module)
+
+
+@pytest.mark.parametrize("page_module", PAGES, indirect=True)
+def test_page_layouts_build(page_module, monkeypatch):
+    """Every page layout must build for an anonymous user.
+
+    These all render the restyled shared cards, so this covers the same
+    construction-time prop errors across everything the redesign touched.
+    """
+    if hasattr(page_module, "get_jwt_from_request"):
+        monkeypatch.setattr(page_module, "get_jwt_from_request", lambda *a, **k: None)
+    if hasattr(page_module, "get_authenticated_user"):
+        monkeypatch.setattr(page_module, "get_authenticated_user", lambda *a, **k: None)
+
+    app = flask.Flask(__name__)
+    app.config["TXV_LOGGER"] = MagicMock()
+    with app.test_request_context("/"):
+        assert page_module.layout() is not None

--- a/tarxiv/tests/test_dashboard_lightcurve.py
+++ b/tarxiv/tests/test_dashboard_lightcurve.py
@@ -173,3 +173,56 @@ def test_extract_object_coordinates_prefers_top_level_decimal(lightcurve_module)
     ra, dec = lightcurve_module._extract_object_coordinates(meta)
 
     assert (ra, dec) == (189.6217156, 39.00305725)
+
+
+def _assignment(name="followup", assignment_id="assign-1"):
+    return {
+        "id": assignment_id,
+        "owner_type": "user",
+        "tag": {"id": "tag-1", "name": name, "color": "#4287f5"},
+    }
+
+
+def test_tagging_panel_carries_callback_ids(lightcurve_module):
+    """The panel must keep the ids its callbacks and the scroll target use."""
+    panel = lightcurve_module.render_tagging_panel(
+        "2023ixf",
+        [{"id": "tag-2", "name": "other", "owner_type": "user"}],
+        [_assignment()],
+    )
+
+    ids = collect_component_ids(panel)
+    assert "object-tag-card" in ids  # scroll target for the head's Tag button
+    assert "assign-object-tag-select" in ids
+    assert "assign-object-tag-button" in ids
+    assert "object-tagging-list" in ids
+
+
+def test_tagging_panel_remove_buttons_keep_pattern_matching_ids(lightcurve_module):
+    """Remove controls are matched by ``assignment_id``; the shape must hold."""
+    panel = lightcurve_module.render_tagging_panel(
+        "2023ixf", [], [_assignment(assignment_id="abc123")]
+    )
+
+    def _dict_ids(component):
+        found = []
+        if not isinstance(component, Component):
+            return found
+        comp_id = getattr(component, "id", None)
+        if isinstance(comp_id, dict):
+            found.append(comp_id)
+        children = getattr(component, "children", None)
+        if isinstance(children, Component):
+            children = [children]
+        if isinstance(children, (list, tuple)):
+            for child in children:
+                found += _dict_ids(child)
+        return found
+
+    assert {"type": "remove-object-tag", "assignment_id": "abc123"} in _dict_ids(panel)
+
+
+def test_tagging_panel_handles_no_assigned_tags(lightcurve_module):
+    panel = lightcurve_module.render_tagging_panel("2023ixf", [], [])
+
+    assert "assign-object-tag-select" in collect_component_ids(panel)

--- a/tarxiv/tests/test_dashboard_lightcurve.py
+++ b/tarxiv/tests/test_dashboard_lightcurve.py
@@ -101,7 +101,7 @@ def _count_id(component, target_id) -> int:
 
 
 def test_format_object_metadata_pieces():
-    """Returns three render pieces and does not embed the tagging container.
+    """Returns four render pieces and does not embed the tagging container.
 
     The tagging container belongs to the base layout, so it must not appear in
     any of the pieces returned here.
@@ -116,12 +116,12 @@ def test_format_object_metadata_pieces():
         "data_sources": {"tns": {"ra_deg": 46.73, "dec_deg": -11.98}},
     }
 
-    results_top, citations_card, full_metadata = format_object_metadata(
+    results_top, metadata_card, citations_card, full_metadata = format_object_metadata(
         "2021njo", meta, citation_str="@article{...}"
     )
 
     combined_ids: set = set()
-    for piece in (results_top, citations_card, full_metadata):
+    for piece in (results_top, metadata_card, citations_card, full_metadata):
         combined_ids |= collect_component_ids(piece)
 
     # The copyable coordinates header is part of the rendered output...
@@ -135,7 +135,7 @@ def test_coordinates_header_omitted_without_coordinates():
     from tarxiv.dashboard.components.cards import format_object_metadata
 
     meta = {"tarxiv_id": "x", "data_sources": {}}
-    results_top, _citations, _full = format_object_metadata("x", meta)
+    results_top, _metadata, _citations, _full = format_object_metadata("x", meta)
 
     assert "object-coordinates" not in collect_component_ids(results_top)
 

--- a/tarxiv/tests/test_dashboard_lightcurve.py
+++ b/tarxiv/tests/test_dashboard_lightcurve.py
@@ -52,9 +52,6 @@ def lightcurve_module(monkeypatch):
 def _render_empty_layout(lightcurve_module, monkeypatch):
     """Render the page layout for the empty (no-object) state."""
     monkeypatch.setattr(lightcurve_module, "get_jwt_from_request", lambda *a, **k: None)
-    monkeypatch.setattr(
-        lightcurve_module, "get_authenticated_user", lambda *a, **k: None
-    )
 
     app = flask.Flask(__name__)
     app.config["TXV_LOGGER"] = MagicMock()

--- a/tarxiv/tests/test_dashboard_object_view.py
+++ b/tarxiv/tests/test_dashboard_object_view.py
@@ -8,12 +8,16 @@ existing only in the photometry -- so those are covered explicitly here.
 
 from dash.development.base_component import Component
 
+from tarxiv.dashboard.components.cards import tag_badge
 from tarxiv.dashboard.components.object_view import (
     EM_DASH,
     build_key_facts,
+    build_page_head,
     build_photometry_table,
+    build_tag_chips,
 )
 from tarxiv.dashboard.styles import BAND_COLORS, resolve_filter_style
+from tarxiv.tests.test_dashboard_lightcurve import collect_component_ids
 
 
 def _facts_by_label(meta, lc_data=None) -> dict:
@@ -250,3 +254,86 @@ def test_filter_style_handles_missing_values():
 
     assert style["light"] == BAND_COLORS["Unknown"][0]
     assert style["dark"] == BAND_COLORS["Unknown"][1]
+
+
+# --------------------------------------------------------------------------
+# tag_badge / page head
+# --------------------------------------------------------------------------
+
+
+def test_tag_badge_passes_hex_colour_through_unchanged():
+    """Regression: the '#' used to be stripped.
+
+    Mantine reads a bare ``4287f5`` as a *named* palette key, fails to resolve
+    it, and renders every custom tag in the fallback colour.
+    """
+    badge = tag_badge({"name": "followup", "color": "#4287f5"})
+
+    assert badge.color == "#4287f5"
+
+
+def test_tag_badge_falls_back_when_colour_missing():
+    assert tag_badge({"name": "x"}).color == "gray"
+    assert tag_badge({"name": "x", "color": None}).color == "gray"
+
+
+def _assignment(name, color="#4287f5", assignment_id="a1"):
+    return {
+        "id": assignment_id,
+        "owner_type": "user",
+        "tag": {"id": "t1", "name": name, "color": color},
+    }
+
+
+def test_build_tag_chips_renders_one_badge_per_assignment():
+    chips = build_tag_chips([_assignment("followup"), _assignment("bright", "#eda100")])
+
+    assert [chip.children for chip in chips] == ["followup", "bright"]
+
+
+def test_build_tag_chips_handles_no_tags():
+    assert build_tag_chips(None) == []
+    assert build_tag_chips([]) == []
+
+
+def test_page_head_has_actions_and_no_duplicate_search():
+    """The head carries the object actions; search lives in the app header.
+
+    A second search box here duplicated the one in the topbar, so it was
+    removed -- but ``_search_controls`` is still used by the empty state, so
+    assert on the head specifically.
+    """
+    head = build_page_head("2023ixf", {"data_sources": {"tns": {}}})
+    ids = collect_component_ids(head)
+
+    assert "jump-to-tags" in ids
+    assert "cite-copy" in ids
+    assert "object-tag-chips" in ids
+    assert "object-id-input" not in ids
+    assert "search-id-button" not in ids
+
+
+def test_page_head_renders_assigned_tags():
+    head = build_page_head(
+        "2023ixf",
+        {"data_sources": {"tns": {"object_type": "SN II"}}},
+        assigned_tags=[_assignment("followup")],
+    )
+
+    def _texts(component):
+        if isinstance(component, str):
+            return [component]
+        found = []
+        children = getattr(component, "children", None)
+        if isinstance(children, Component):
+            children = [children]
+        if isinstance(children, (list, tuple)):
+            for child in children:
+                found += _texts(child)
+        elif isinstance(children, str):
+            found.append(children)
+        return found
+
+    texts = _texts(head)
+    assert "followup" in texts
+    assert "SN II" in texts

--- a/tarxiv/tests/test_dashboard_object_view.py
+++ b/tarxiv/tests/test_dashboard_object_view.py
@@ -1,0 +1,252 @@
+"""Tests for the object-page builders and the lightcurve series styling.
+
+``build_key_facts`` has to cope with several quirks of the stored metadata --
+the host arriving under ``hostname``, peak magnitudes living in a plural
+``peak_mags`` list with the value under the key ``limit``, and detection counts
+existing only in the photometry -- so those are covered explicitly here.
+"""
+
+from dash.development.base_component import Component
+
+from tarxiv.dashboard.components.object_view import (
+    EM_DASH,
+    build_key_facts,
+    build_photometry_table,
+)
+from tarxiv.dashboard.styles import BAND_COLORS, resolve_filter_style
+
+
+def _facts_by_label(meta, lc_data=None) -> dict:
+    return {fact["label"]: fact for fact in build_key_facts(meta, lc_data)}
+
+
+# --------------------------------------------------------------------------
+# build_key_facts
+# --------------------------------------------------------------------------
+
+
+def test_key_facts_returns_six_facts_for_empty_metadata():
+    facts = build_key_facts({}, None)
+
+    assert len(facts) == 6
+    assert all(fact["value"] == EM_DASH for fact in facts)
+
+
+def test_key_facts_reads_host_from_tns_hostname_key():
+    """The TNS ingest writes the host under "hostname", not "host_name"."""
+    meta = {"data_sources": {"tns": {"hostname": "M101"}}}
+
+    assert _facts_by_label(meta)["Host"]["value"] == "M101"
+
+
+def test_key_facts_falls_back_to_sherlock_catalogue_object():
+    meta = {"data_sources": {"sherlock": {"catalogue_object_id": "NGC 5457"}}}
+
+    assert _facts_by_label(meta)["Host"]["value"] == "NGC 5457"
+
+
+def test_key_facts_prefers_tns_redshift_over_sherlock():
+    meta = {
+        "data_sources": {
+            "tns": {"redshift": 0.000804},
+            "sherlock": {"redshift": 0.5},
+        }
+    }
+
+    assert _facts_by_label(meta)["Redshift"]["value"] == "0.000804"
+
+
+def test_key_facts_uses_sherlock_redshift_when_tns_missing():
+    meta = {"data_sources": {"tns": {}, "sherlock": {"redshift": 0.021}}}
+
+    assert _facts_by_label(meta)["Redshift"]["value"] == "0.021"
+
+
+def test_key_facts_peak_magnitude_reads_value_under_limit_key():
+    """summarize_lc_mags stores the peak magnitude under "limit"."""
+    meta = {
+        "data_sources": {
+            "ztf": {"peak_mags": [{"filter": "g", "limit": 11.58, "date": "60090.21"}]}
+        }
+    }
+
+    peak = _facts_by_label(meta)["Peak mag"]
+    assert peak["value"] == "11.6"
+    assert peak["unit"] == "g"
+
+
+def test_key_facts_peak_magnitude_takes_brightest_across_sources():
+    meta = {
+        "data_sources": {
+            "ztf": {"peak_mags": [{"filter": "g", "limit": 11.58}]},
+            "atlas": {"peak_mags": [{"filter": "o", "limit": 10.94}]},
+        }
+    }
+
+    peak = _facts_by_label(meta)["Peak mag"]
+    # Brightest == numerically smallest magnitude.
+    assert peak["value"] == "10.9"
+    assert peak["unit"] == "o"
+
+
+def test_key_facts_peak_magnitude_ignores_unparseable_entries():
+    meta = {
+        "data_sources": {
+            "ztf": {"peak_mags": [{"filter": "g", "limit": None}, "junk"]},
+        }
+    }
+
+    assert _facts_by_label(meta)["Peak mag"]["value"] == EM_DASH
+
+
+def test_key_facts_discovery_date_trimmed_and_carries_reporting_group():
+    meta = {
+        "discovery_date": "2023-05-19T17:27:15",
+        "data_sources": {"tns": {"reporting_group": "Itagaki"}},
+    }
+
+    discovered = _facts_by_label(meta)["Discovered"]
+    assert discovered["value"] == "2023-05-19"
+    assert discovered["unit"] == "Itagaki"
+
+
+def test_key_facts_numeric_distance_gets_mpc_unit():
+    meta = {"data_sources": {"sherlock": {"best_distance": 6.8512}}}
+
+    distance = _facts_by_label(meta)["Distance"]
+    assert distance["value"] == "6.85"
+    assert distance["unit"] == "Mpc"
+
+
+def test_key_facts_string_distance_passes_through_without_unit():
+    meta = {"data_sources": {"sherlock": {"best_distance": "unknown"}}}
+
+    distance = _facts_by_label(meta)["Distance"]
+    assert distance["value"] == "unknown"
+    assert distance["unit"] is None
+
+
+def test_key_facts_counts_detections_and_lists_surveys():
+    lc_data = [
+        {"detection": 1, "survey": "ztf"},
+        {"detection": 1, "survey": "atlas"},
+        {"detection": 0, "survey": "atlas"},  # non-detection, not counted
+        {"detection": -1, "survey": "ztf"},  # bad quality, not counted
+    ]
+
+    detections = _facts_by_label({}, lc_data)["Detections"]
+    assert detections["value"] == "2"
+    assert detections["unit"] == "ATLAS + ZTF"
+
+
+# --------------------------------------------------------------------------
+# build_photometry_table
+# --------------------------------------------------------------------------
+
+
+def _table_text(component) -> str:
+    """Flatten a component tree into a string of its text content."""
+    if isinstance(component, str):
+        return component
+    if isinstance(component, (int, float)):
+        return str(component)
+    if isinstance(component, (list, tuple)):
+        return " ".join(_table_text(child) for child in component)
+    if isinstance(component, Component):
+        return _table_text(getattr(component, "children", None) or [])
+    return ""
+
+
+def test_photometry_table_empty_state():
+    table = build_photometry_table([], "light")
+
+    assert "No photometry available" in _table_text(table)
+
+
+def test_photometry_table_renders_detections_and_limits():
+    points = [
+        {
+            "mjd": 60090.2,
+            "mag": 11.58,
+            "mag_err": 0.02,
+            "filter": "g",
+            "survey": "ztf",
+            "detection": 1,
+        },
+        {
+            "mjd": 60082.9,
+            "limit": 19.24,
+            "filter": "o",
+            "survey": "atlas",
+            "detection": 0,
+        },
+    ]
+
+    text = _table_text(build_photometry_table(points, "light"))
+
+    assert "ZTF g" in text
+    assert "11.58" in text
+    # Non-detections are rendered as upper limits with no uncertainty.
+    assert "> 19.24" in text
+    assert "limit" in text
+
+
+def test_photometry_table_sorts_by_epoch_and_drops_bad_quality():
+    points = [
+        {"mjd": 60100.0, "mag": 15.0, "filter": "r", "survey": "ztf", "detection": 1},
+        {"mjd": 60000.0, "mag": 14.0, "filter": "r", "survey": "ztf", "detection": 1},
+        {"mjd": 60050.0, "mag": 99.0, "filter": "r", "survey": "ztf", "detection": -1},
+        {"mjd": None, "mag": 13.0, "filter": "r", "survey": "ztf", "detection": 1},
+    ]
+
+    text = _table_text(build_photometry_table(points, "light"))
+
+    assert text.index("60000.00") < text.index("60100.00")
+    # detection == -1 and missing MJD are both excluded.
+    assert "60050.00" not in text
+    assert "99.00" not in text
+
+
+# --------------------------------------------------------------------------
+# resolve_filter_style
+# --------------------------------------------------------------------------
+
+
+def test_filter_style_core_bands_use_validated_colours():
+    assert resolve_filter_style("ztf", "g")["light"] == BAND_COLORS["g"][0]
+    assert resolve_filter_style("atlas", "o")["dark"] == BAND_COLORS["o"][1]
+
+
+def test_filter_style_symbol_tracks_band_for_cvd_safety():
+    """Bands g and r differ in shape as well as hue.
+
+    Green/red sits in the 6-8 CVD separation band, which is only legal with a
+    secondary encoding, so symbol has to move with the band.
+    """
+    assert (
+        resolve_filter_style("ztf", "g")["symbol"]
+        != resolve_filter_style("ztf", "r")["symbol"]
+    )
+
+
+def test_filter_style_same_band_matches_across_surveys():
+    """The same bandpass renders identically whichever survey reported it."""
+    assert resolve_filter_style("ztf", "g") == resolve_filter_style("asas-sn", "g")
+
+
+def test_filter_style_normalises_ztf_capital_r():
+    assert resolve_filter_style("ztf", "R")["light"] == BAND_COLORS["r"][0]
+
+
+def test_filter_style_unknown_band_folds_to_neutral():
+    style = resolve_filter_style("mystery-survey", "q")
+
+    assert style["light"] == BAND_COLORS["Unknown"][0]
+    assert style["symbol"] == "x"
+
+
+def test_filter_style_handles_missing_values():
+    style = resolve_filter_style(None, None)
+
+    assert style["light"] == BAND_COLORS["Unknown"][0]
+    assert style["dark"] == BAND_COLORS["Unknown"][1]

--- a/tarxiv/tests/test_dashboard_plots.py
+++ b/tarxiv/tests/test_dashboard_plots.py
@@ -12,6 +12,7 @@ from tarxiv.dashboard.components.plots import (
     empty_lightcurve_plot,
 )
 from tarxiv.dashboard.components.theme_manager import register_tarxiv_templates
+from tarxiv.dashboard.styles import BAND_COLORS
 
 
 @pytest.fixture(autouse=True)
@@ -88,3 +89,79 @@ def test_empty_lightcurve_plot_custom_message():
     fig = empty_lightcurve_plot("2018mqw", "tarxiv_dark", message="Nothing here")
 
     assert "Nothing here" in _annotation_texts(fig)
+
+
+def _two_band_points():
+    return [
+        {
+            "mjd": 58243.1,
+            "mag": 18.87,
+            "mag_err": 0.012,
+            "filter": "g",
+            "survey": "ztf",
+            "detection": 1,
+        },
+        {
+            "mjd": 58244.2,
+            "limit": 20.1,
+            "filter": "o",
+            "survey": "atlas",
+            "detection": 0,
+        },
+    ]
+
+
+def test_traces_are_named_by_survey_and_band():
+    fig = create_lightcurve_plot(_two_band_points(), "2018mqw", "tarxiv_light")
+
+    names = [trace.name for trace in fig.data]
+    assert "ZTF g" in names
+
+
+def test_detection_trace_styling_and_hover():
+    fig = create_lightcurve_plot(_two_band_points(), "2018mqw", "tarxiv_light")
+
+    detection = next(t for t in fig.data if t.name == "ZTF g")
+    # Symbol encodes the survey (ZTF -> circle), colour encodes the band.
+    assert detection.marker.symbol == "circle"
+    assert detection.marker.color == BAND_COLORS["g"][0]
+    # Error bars are hairlines with no caps.
+    assert detection.error_y.width == 0
+    assert detection.error_y.thickness == 1.2
+    # Uncertainty is surfaced on hover via customdata.
+    assert "customdata" in detection.hovertemplate
+
+
+def test_dark_scheme_uses_dark_band_colours():
+    points = [
+        {
+            "mjd": 58243.1,
+            "mag": 18.0,
+            "mag_err": 0.01,
+            "filter": "o",
+            "survey": "atlas",
+            "detection": 1,
+        }
+    ]
+
+    fig = create_lightcurve_plot(points, "2018mqw", "tarxiv_dark")
+
+    assert fig.data[0].marker.color == BAND_COLORS["o"][1]
+
+
+def test_limit_traces_are_hollow_and_absent_from_legend():
+    fig = create_lightcurve_plot(_two_band_points(), "2018mqw", "tarxiv_light")
+
+    limit = next(t for t in fig.data if "limit" in (t.name or ""))
+    assert limit.marker.symbol == "triangle-down-open"
+    assert limit.showlegend is False
+
+
+def test_axis_formatting_for_mjd_and_magnitude():
+    fig = create_lightcurve_plot(_two_band_points(), "2018mqw", "tarxiv_light")
+
+    # MJDs are large integers; ".2f" ticks read as noise.
+    assert fig.layout.xaxis.tickformat == "d"
+    assert fig.layout.yaxis.autorange == "reversed"
+    # The card header carries the title, so the figure must not repeat it.
+    assert fig.layout.title.text is None


### PR DESCRIPTION
Following-on from some mockups evaluated with Heloise, I've gone for a redesign of the UI/styling to better present lightcurve data and generally lay out the page a bit better. 

<img width="1535" height="1350" alt="image" src="https://github.com/user-attachments/assets/9cde93d4-f632-4292-b92b-72bbdf2ad902" />

Generally we have:
- Style rejig, more lighter colours and red is now an accent rather than a primary
- Column view rather then full-width
- Tags at top
- Tag + cite buttons at top
- Top bar with at-a-glance info on it (not entirely convinced on this at second glance)
- lightcurve next to skymap, and tags/citations/metadata all on second row
- Sidebar moved to header with search bar
- Collapses into single column on narrower monitors (i.e. laptop screens)

Feedback welcome @HeloiseS @gonzodeveloper @JulienPeloton

